### PR TITLE
UIDEXP-30: Update stripes to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 * Add running jobs components to display temp static data. Refs UIDEXP-6.
 * Implement logic for initiating the export job process once the user has selected file. Refs UIDEXP-20.
 * Add validation to QueryFileUploaderComponent to let user upload only file with csv extension. UIDEXP-21.
+* Updated `stripes` to `v3.0.0`, `stripes-core` to `4.0.0` and `react-intl` to `2.9.0`. UIDEXP-30.

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-core": "^3.11.0",
+    "@folio/stripes-core": "^4.0.0",
     "@folio/stripes-cli": "^1.11.0",
     "@folio/stripes-smart-components": "^2.12.0",
-    "@folio/stripes": "^2.12.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/stripes-data-transfer-components": "^1.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
@@ -44,12 +44,12 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.4",
     "prop-types": "^15.6.0",
-    "react-intl": "^2.3.0",
+    "react-intl": "^2.9.0",
     "redux-form": "^7.0.3",
     "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.13.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"


### PR DESCRIPTION
## Purpose:
Updated 
`stripes` to `v3.0.0`, 
`stripes-core` to `4.0.0`,
`react-intl` to `2.9.0`

## Task:
[UIDEXP-30](https://issues.folio.org/browse/UIDEXP-30)

## Note:
Please, update your core `package.json`:
```javascript
"dependencies": {
    "@folio/stripes": "^3.0.0"
  },
  "resolutions": {
    "@folio/stripes": "^3.0.0"
  }
```
### Also:
If you use `stripes-sample-platform`, please, update `package.json` here too:
```javascript
"dependencies": {
    "@folio/stripes": "^3.0.0"
  }
```