### PR TITLE
UIDEXP-20: Set dependency on the "data-export" backend interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 * Add running jobs components to display temp static data. Refs UIDEXP-6.
 * Implement logic for initiating the export job process once the user has selected file. Refs UIDEXP-20.
 * Add validation to QueryFileUploaderComponent to let user upload only file with csv extension. UIDEXP-21.
-* Updated `stripes` to `v3.0.0`, `stripes-core` to `4.0.0` and `react-intl` to `2.9.0`. UIDEXP-30.
+* Update `stripes` to `v3.0.0`, `stripes-core` to `4.0.0` and `react-intl` to `2.9.0`. UIDEXP-30.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
         "title": "Data export"
       }
     ],
+    "okapiInterfaces": {
+      "data-export": "1.0"
+    },
     "permissionSets": [
       {
         "permissionName": "module.data-export.enabled",

--- a/src/components/QueryFileUploader/QueryFileUploader.js
+++ b/src/components/QueryFileUploader/QueryFileUploader.js
@@ -202,6 +202,7 @@ QueryFileUploaderComponent.manifest = Object.freeze({
   export: {
     type: 'okapi',
     path: 'data-export/export',
+    clientGeneratePk: false,
     throwErrors: false,
     fetch: false,
   },


### PR DESCRIPTION
## Purpose

1. Set dependency on the "data-export": "1.0" backend interface
2. Prevent generating of client ID for initiation export job request (It turned out requests created with the help of manifest generate it by default. In order to prevent it `clientGeneratePk: false` should be used for the resource) as it causes error response on the server about the unexpected `id` field.

## Task
[UIDEXP-20](https://issues.folio.org/browse/UIDEXP-20)