### PR TITLE
UIDEXP-35: Populate hrId fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-data-export
 
 ## 1.1.0 (IN PROGRESS)
+* Populate JobId field on Job logs, update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-35. 
 
 ## [1.0.0](https://github.com/folio-org/ui-data-export/tree/v1.0.0) (2020-03-13)
 * UI app created. Refs UIDEXP-8.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes-core": "^4.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-smart-components": "^2.12.0",
+    "@folio/stripes-smart-components": "^3.0.0",
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-data-transfer-components": "^1.0.0",
     "babel-eslint": "^9.0.0",

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -49,6 +49,7 @@ const columnMapping = {
 
 const visibleColumns = [
   'fileName',
+  'hrId',
   'jobProfileName',
   'completedDate',
   'status',

--- a/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
+++ b/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
@@ -24,13 +24,14 @@ const formatTime = dateStr => {
   return <span>{datePart} {timePart} {todayPart}</span>;
 };
 
-// TODO: remove defaults for jobProfileInfo, hrId and runBy once backend is in place
+// TODO: remove defaults for jobProfileInfo and runBy once backend is in place
 const JobDetails = props => {
   const { job } = props;
 
   const {
     jobProfileInfo,
     exportedFiles,
+    hrId,
     runBy,
     startedDate,
   } = job;
@@ -42,7 +43,7 @@ const JobDetails = props => {
         <span data-test-running-job-file-name>{get(exportedFiles, '0.fileName')}</span>
       </div>
       <div className={css.delimiter}>
-        <span data-test-running-job-hr-id>{get(job, 'hrId', '')}</span>
+        <span data-test-running-job-hr-id>{hrId}</span>
         {runBy && (
           <span data-test-running-job-triggered-by>
             <FormattedMessage

--- a/test/bigtest/tests/jobLogs-test.js
+++ b/test/bigtest/tests/jobLogs-test.js
@@ -5,6 +5,7 @@ import {
   it,
 } from '@bigtest/mocha';
 
+import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 import translations from '../../../translations/ui-data-export/en';
 import { setupApplication } from '../helpers';
 import { jobLogsContainerInteractor } from '../interactors';
@@ -24,21 +25,25 @@ describe('Job logs list', () => {
     });
 
     it('should add status column to the end', () => {
-      expect(jobLogsContainerInteractor.logsList.headers(3).text).to.equal(translations.status);
+      expect(jobLogsContainerInteractor.logsList.headers(4).text).to.equal(translations.status);
     });
 
     it('should be sorted by "completedDate" descending by default', () => {
-      expect(getCellContent(0, 3)).to.equal('Fail');
-      expect(getCellContent(1, 3)).to.equal('Success');
+      expect(getCellContent(0, 4)).to.equal('Fail');
+      expect(getCellContent(1, 4)).to.equal('Success');
+    });
+
+    it('should render ID column', () => {
+      expect(jobLogsContainerInteractor.logsList.headers(1).text).to.equal(commonTranslations.jobExecutionHrId);
     });
 
     describe('clicking on status header', () => {
       beforeEach(async () => {
-        await jobLogsContainerInteractor.logsList.headers(3).click();
+        await jobLogsContainerInteractor.logsList.headers(4).click();
       });
 
       it('should sort by status in ascending order', () => {
-        expect(getCellContent(1, 3)).to.equal('Success');
+        expect(getCellContent(1, 4)).to.equal('Success');
       });
 
       it('should have the correct query in path', function () {
@@ -47,12 +52,12 @@ describe('Job logs list', () => {
 
       describe('clicking on status header', () => {
         beforeEach(async () => {
-          await jobLogsContainerInteractor.logsList.headers(3).click();
+          await jobLogsContainerInteractor.logsList.headers(4).click();
         });
 
         it('should sort by status in descending order', () => {
-          expect(getCellContent(1, 3)).to.equal('Fail');
-          expect(getCellContent(0, 3)).to.equal('Success');
+          expect(getCellContent(1, 4)).to.equal('Fail');
+          expect(getCellContent(0, 4)).to.equal('Success');
         });
 
         it('should have the correct query in path', function () {
@@ -68,6 +73,21 @@ describe('Job logs list', () => {
 
       it('should not show error notification', () => {
         expect(jobLogsContainerInteractor.callout.errorCalloutIsPresent).to.be.false;
+      });
+    });
+
+    describe('clicking on ID header', () => {
+      beforeEach(async () => {
+        await jobLogsContainerInteractor.logsList.headers(1).click();
+      });
+
+      it('should sort by number from ID field', () => {
+        expect(getCellContent(0, 1)).to.equal('2');
+        expect(getCellContent(1, 1)).to.equal('4');
+      });
+
+      it('should have the correct query in path', function () {
+        expect(this.location.search.includes('direction=ascending&sort=hrId')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Purpose:
Populate Job Id in "Running jobs" and "Logs" components on the landing page.

[UIDEXP-35](https://issues.folio.org/browse/UIDEXP-35)

## Screenshot:
![Screenshot 2020-03-20 at 21 51 02](https://user-images.githubusercontent.com/60929399/77201286-e8e35b00-6af4-11ea-805d-2b51f5d2f0ae.png)



