### PR TITLE
UIDEXP-37: Populate runBy on Job logs & Running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change history for ui-data-export
 
 ## 1.1.0 (IN PROGRESS)
-* Populate JobId field on Job logs, update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-35. 
+* Populate jobId field on job logs, update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-35.
+* Populate runBy field on jobs logs and running jobs. UIDEXP-37.
 
 ## [1.0.0](https://github.com/folio-org/ui-data-export/tree/v1.0.0) (2020-03-13)
 * UI app created. Refs UIDEXP-8.

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -52,6 +52,7 @@ const visibleColumns = [
   'hrId',
   'jobProfileName',
   'completedDate',
+  'runBy',
   'status',
 ];
 

--- a/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
+++ b/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
@@ -24,7 +24,7 @@ const formatTime = dateStr => {
   return <span>{datePart} {timePart} {todayPart}</span>;
 };
 
-// TODO: remove defaults for jobProfileInfo and runBy once backend is in place
+// TODO: remove defaults for jobProfileInfo once backend is in place
 const JobDetails = props => {
   const { job } = props;
 
@@ -32,7 +32,10 @@ const JobDetails = props => {
     jobProfileInfo,
     exportedFiles,
     hrId,
-    runBy,
+    runBy: {
+      firstName,
+      lastName,
+    },
     startedDate,
   } = job;
 
@@ -44,14 +47,12 @@ const JobDetails = props => {
       </div>
       <div className={css.delimiter}>
         <span data-test-running-job-hr-id>{hrId}</span>
-        {runBy && (
-          <span data-test-running-job-triggered-by>
-            <FormattedMessage
-              id="ui-data-export.triggeredBy"
-              values={{ userName: `${runBy.firstName} ${runBy.lastName}` }}
-            />
-          </span>
-        )}
+        <span data-test-running-job-triggered-by>
+          <FormattedMessage
+            id="ui-data-export.triggeredBy"
+            values={{ userName: `${firstName} ${lastName}` }}
+          />
+        </span>
       </div>
       <div className={css.delimiter}>
         <span data-test-running-job-date-label>

--- a/test/bigtest/network/scenarios/fetch-job-profiles-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-profiles-success.js
@@ -1,3 +1,13 @@
+export const testUserOzzy = {
+  firstName: 'Ozzy',
+  lastName: 'Campenshtorm',
+};
+
+export const testUserElliot = {
+  firstName: 'Elliot',
+  lastName: 'Lane',
+};
+
 export const runningJobExecutions = [
   {
     id: 'de96f7a1-8706-42e9-ba86-c44c44592511',
@@ -42,8 +52,8 @@ export const logJobExecutions = [
       total: 512,
     },
     runBy: {
-      firstName: 'Ozzy',
-      lastName: 'Campenshtorm',
+      firstName: testUserOzzy.firstName,
+      lastName: testUserOzzy.lastName,
     },
     startedDate: '2018-11-05T14:22:57.000+0000',
     completedDate: '2018-11-11T14:10:34.000+0000',
@@ -66,8 +76,8 @@ export const logJobExecutions = [
       total: 5000,
     },
     runBy: {
-      firstName: 'Elliot',
-      lastName: 'Lane',
+      firstName: testUserElliot.firstName,
+      lastName: testUserElliot.lastName,
     },
     completedDate: '2018-11-05T14:22:57.000+0000',
     startedDate: '2018-11-05T14:22:57.000+0000',

--- a/test/bigtest/tests/jobLogs-test.js
+++ b/test/bigtest/tests/jobLogs-test.js
@@ -9,6 +9,10 @@ import commonTranslations from '@folio/stripes-data-transfer-components/translat
 import translations from '../../../translations/ui-data-export/en';
 import { setupApplication } from '../helpers';
 import { jobLogsContainerInteractor } from '../interactors';
+import {
+  testUserOzzy,
+  testUserElliot,
+} from '../network/scenarios/fetch-job-profiles-success';
 
 const getCellContent = (row, cell) => jobLogsContainerInteractor.logsList.rows(row).cells(cell).content;
 
@@ -25,25 +29,29 @@ describe('Job logs list', () => {
     });
 
     it('should add status column to the end', () => {
-      expect(jobLogsContainerInteractor.logsList.headers(4).text).to.equal(translations.status);
+      expect(jobLogsContainerInteractor.logsList.headers(5).text).to.equal(translations.status);
     });
 
     it('should be sorted by "completedDate" descending by default', () => {
-      expect(getCellContent(0, 4)).to.equal('Fail');
-      expect(getCellContent(1, 4)).to.equal('Success');
+      expect(getCellContent(0, 5)).to.equal('Fail');
+      expect(getCellContent(1, 5)).to.equal('Success');
     });
 
     it('should render ID column', () => {
       expect(jobLogsContainerInteractor.logsList.headers(1).text).to.equal(commonTranslations.jobExecutionHrId);
     });
 
+    it('should render Run by column', () => {
+      expect(jobLogsContainerInteractor.logsList.headers(4).text).to.equal(commonTranslations.runBy);
+    });
+
     describe('clicking on status header', () => {
       beforeEach(async () => {
-        await jobLogsContainerInteractor.logsList.headers(4).click();
+        await jobLogsContainerInteractor.logsList.headers(5).click();
       });
 
       it('should sort by status in ascending order', () => {
-        expect(getCellContent(1, 4)).to.equal('Success');
+        expect(getCellContent(1, 5)).to.equal('Success');
       });
 
       it('should have the correct query in path', function () {
@@ -52,12 +60,12 @@ describe('Job logs list', () => {
 
       describe('clicking on status header', () => {
         beforeEach(async () => {
-          await jobLogsContainerInteractor.logsList.headers(4).click();
+          await jobLogsContainerInteractor.logsList.headers(5).click();
         });
 
         it('should sort by status in descending order', () => {
-          expect(getCellContent(1, 4)).to.equal('Fail');
-          expect(getCellContent(0, 4)).to.equal('Success');
+          expect(getCellContent(1, 5)).to.equal('Fail');
+          expect(getCellContent(0, 5)).to.equal('Success');
         });
 
         it('should have the correct query in path', function () {
@@ -88,6 +96,24 @@ describe('Job logs list', () => {
 
       it('should have the correct query in path', function () {
         expect(this.location.search.includes('direction=ascending&sort=hrId')).to.be.true;
+      });
+    });
+
+    describe('clicking on Run by header', () => {
+      beforeEach(async () => {
+        await jobLogsContainerInteractor.logsList.headers(4).click();
+      });
+
+      it('should sort by User name from Run by field', () => {
+        const userOzzy = `${testUserOzzy.firstName} ${testUserOzzy.lastName}`;
+        const userElliot = `${testUserElliot.firstName} ${testUserElliot.lastName}`;
+
+        expect(getCellContent(0, 4)).to.equal(userElliot);
+        expect(getCellContent(1, 4)).to.equal(userOzzy);
+      });
+
+      it('should have the correct query in path', function () {
+        expect(this.location.search.includes('direction=ascending&sort=runBy')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## Purpose:
Populate Run by in "Running jobs" and "Logs" components on the landing page.

[UIDEXP-37](https://issues.folio.org/browse/UIDEXP-37)

## Screenshot:
![Screenshot 2020-03-20 at 22 55 35](https://user-images.githubusercontent.com/60929399/77205622-ecc7ab00-6afd-11ea-90e7-a2323e3fe827.png)
