### PR TITLE
UIDEXP-40: Add static search form on field mapping profiles settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Populate jobId field on job logs, update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-35.
 * Populate runBy field on jobs logs and running jobs. UIDEXP-37.
 * Init second pane navigation in settings and link to field mapping profiles section. UIDEXP-39.
+* Add static search form on field mapping profiles settings page. UIDEXP-40.
 
 ## [1.0.0](https://github.com/folio-org/ui-data-export/tree/v1.0.0) (2020-03-13)
 * UI app created. Refs UIDEXP-8.

--- a/src/components/QueryFileUploader/QueryFileUploader.js
+++ b/src/components/QueryFileUploader/QueryFileUploader.js
@@ -16,7 +16,7 @@ import {
   Layout,
   Callout,
   ConfirmationModal,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import {
   useStripes,
   stripesConnect,

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import {
   Paneset,
   Pane,
-} from '@folio/stripes-components';
+} from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 import {
   DataFetcher,

--- a/src/settings/MappingProfiles/MappingProfiles.js
+++ b/src/settings/MappingProfiles/MappingProfiles.js
@@ -1,8 +1,30 @@
 import React from 'react';
 
+import {
+  SettingsLabel,
+  SearchForm,
+} from '@folio/stripes-data-transfer-components';
+import { Pane } from '@folio/stripes/components';
+
 const MappingProfiles = () => {
   return (
-    <span>Mapping profiles</span>
+    <Pane
+      data-test-mapping-profiles-pane
+      defaultWidth="fill"
+      paneTitle={(
+        <SettingsLabel
+          messageId="ui-data-export.mappingProfilesTitle"
+          iconKey="mappingProfiles"
+          app="data-export"
+        />
+      )}
+    >
+      <SearchForm
+        searchTerm=" "
+        contextName="data-export"
+        searchLabelKey="ui-data-export.search"
+      />
+    </Pane>
   );
 };
 

--- a/test/bigtest/interactors/settings/index.js
+++ b/test/bigtest/interactors/settings/index.js
@@ -1,1 +1,2 @@
 export { default as SettingsSectionsPaneInteractor } from './SettingsSectionsPaneInteractor';
+export * from './mappingProfilesInteractor';

--- a/test/bigtest/interactors/settings/mappingProfilesInteractor.js
+++ b/test/bigtest/interactors/settings/mappingProfilesInteractor.js
@@ -1,0 +1,15 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+import { SearchFormInteractor } from '@folio/stripes-data-transfer-components/interactors';
+
+@interactor class MappingProfilesInteractor {
+  static defaultScope = '[data-test-mapping-profiles-pane]';
+
+  searchForm = new SearchFormInteractor();
+  paneTitle = scoped('[data-test-settings-label]');
+}
+
+export const mappingProfilesInteractor = new MappingProfilesInteractor();

--- a/test/bigtest/tests/mappingProfiles-test.js
+++ b/test/bigtest/tests/mappingProfiles-test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+
+import { setupApplication } from '../helpers';
+import { mappingProfilesInteractor } from '../interactors';
+import translations from '../../../translations/ui-data-export/en';
+
+describe('Field mapping profiles settings', () => {
+  setupApplication();
+
+  beforeEach(function () {
+    this.visit('/settings/data-export/mapping-profiles');
+  });
+
+  it('should be visible', () => {
+    expect(mappingProfilesInteractor.isPresent).to.be.true;
+  });
+
+  it('should display field mapping profiles section', () => {
+    expect(mappingProfilesInteractor.paneTitle.text).to.equal(translations.mappingProfilesTitle);
+  });
+
+  it('should contain search form', () => {
+    expect(mappingProfilesInteractor.searchForm.isPresent).to.be.true;
+  });
+});

--- a/test/bigtest/tests/settings-test.js
+++ b/test/bigtest/tests/settings-test.js
@@ -23,7 +23,7 @@ describe('Settings', () => {
 
   it('should be visible', () => {
     expect(settingsDisplayInteractor.isPresent).to.be.true;
-    expect(settingsDisplayInteractor.text).to.equal('Data export');
+    expect(settingsDisplayInteractor.text).to.equal(translations['settings.index.paneTitle']);
   });
 
   it('should display profiles label', () => {
@@ -34,16 +34,16 @@ describe('Settings', () => {
     expect(settingsSectionsPane.sectionsLabels(0).isPresent).to.be.true;
   });
 
-  it('should display field mapping profile section', () => {
+  it('should display field mapping profiles section', () => {
     expect(settingsSectionsPane.sectionsLabels(0).text).to.equal(translations.mappingProfilesTitle);
   });
 
-  describe('clicking on field mapping profile navigation item', () => {
+  describe('clicking on field mapping profiles navigation item', () => {
     beforeEach(async () => {
       await settingsSectionsPane.navigationItems(0).click();
     });
 
-    it('should navigate to field mapping profile section', function () {
+    it('should navigate to field mapping profiles section', function () {
       expect(this.location.pathname.endsWith('mapping-profiles')).to.be.true;
     });
   });


### PR DESCRIPTION
## Purpose

Add static search form on field mapping profiles settings page in the scope of the [UIDEXP-40](https://issues.folio.org/browse/UIDEXP-40).
<img width="1335" alt="Screen Shot 2020-03-27 at 16 50 54" src="https://user-images.githubusercontent.com/40821852/77768480-360e8200-704b-11ea-83a0-5856481ca202.png">

