### PR TITLE
UIDEXP-56: Retrieve only latest logs on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Populate runBy field on jobs logs and running jobs. UIDEXP-37.
 * Init second pane navigation in settings and link to field mapping profiles section. UIDEXP-39.
 * Add static search form on field mapping profiles settings page. UIDEXP-40.
+* Retrieve only latest logs on landing page. Fixes UIDEXP-56.
 
 ## [1.0.0](https://github.com/folio-org/ui-data-export/tree/v1.0.0) (2020-03-13)
 * UI app created. Refs UIDEXP-8.

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -62,7 +62,7 @@ const jobsUrl = createUrl('data-export/jobExecutions', {
 }, false);
 
 const logsUrl = createUrl('data-export/jobExecutions', {
-  query: `status=(${JOB_EXECUTION_STATUSES.SUCCESS} OR ${JOB_EXECUTION_STATUSES.FAIL})`,
+  query: `status=(${JOB_EXECUTION_STATUSES.SUCCESS} OR ${JOB_EXECUTION_STATUSES.FAIL}) sortBy completedDate/sort.descending`,
   limit: 25,
 }, false);
 


### PR DESCRIPTION
## Purpose

Retrieve only the latest logs on landing page in the scope of the [UIDEXP-56](https://issues.folio.org/browse/UIDEXP-56).