### PR TITLE
UIDEXP-67: Provide missing "module.data-export.enabled" permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change history for ui-data-export
 
 ## 1.1.0 (IN PROGRESS)
-
 * Init second pane navigation in settings and link to field mapping profiles section. UIDEXP-39.
 * Add static search form on field mapping profiles settings page. UIDEXP-40.
+* Provide missing "module.data-export.enabled" permission. Fixes UIDEXP-67.
 
 ## [1.0.1](https://github.com/folio-org/ui-data-export/tree/v1.0.1) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.0...v1.0.1)

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
           "data-export.file-definitions.item.post",
           "data-export.file-definitions.upload.post",
           "data-export.export.post",
+          "data-export.job-executions.items.get",
           "data-export.job-executions.items.download.get"
         ],
         "visible": true


### PR DESCRIPTION
## Purpose

Provide missing "module.data-export.enabled" permission in the scope of the [UIDEXP-67](https://issues.folio.org/browse/UIDEXP-67).