### PR TITLE
UIDEXP-68: Handle case when 'progress' field is missing from log detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add static search form on field mapping profiles settings page. UIDEXP-40.
 * Add static mapping profiles list to field mapping settings pane. UIDEXP-41.
 * Accommodate UI to the change of the export job API endpoint. UIDEXP-44.
+* Handle case when progress field is missing from log detail. UIDEXP-68.
 
 ## [1.0.2](https://github.com/folio-org/ui-data-export/tree/v1.0.2) (2020-04-03)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.1...v1.0.2)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -104,7 +104,7 @@ const JobLogsContainer = props => {
   const getRecordsField = record => {
     if (record.status === JOB_EXECUTION_STATUSES.FAIL) return null;
 
-    return record.progress.current;
+    return get(record, 'progress.current', '');
   };
 
   return (


### PR DESCRIPTION
## Purpose

Handle case when 'progress' field is missing from log detail in the scope of [UIDEXP-68](https://issues.folio.org/browse/UIDEXP-68).