### PR TITLE
UIDEXP-62: Add button to navigate to all logs view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add static mapping profiles list to field mapping settings pane. UIDEXP-41.
 * Accommodate UI to the change of the export job API endpoint. UIDEXP-44.
 * Handle case when progress field is missing from log detail. UIDEXP-68.
+* Add button to navigate to all logs view. UIDEXP-62.
 
 ## [1.0.2](https://github.com/folio-org/ui-data-export/tree/v1.0.2) (2020-04-03)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.1...v1.0.2)

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import {
   Paneset,
   Pane,
+  Button,
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 import {
@@ -20,6 +21,17 @@ import { DataFetcherContext } from '../contexts/DataFetcherContext';
 import { JOB_EXECUTION_STATUSES } from '../utils/constants';
 
 function Home(props) {
+  const viewAllLogsButton = (
+    <Button
+      buttonStyle="primary paneHeaderNewButton"
+      data-test-view-all-logs-button
+      marginBottom0
+      to=""
+    >
+      <FormattedMessage id="ui-data-export.viewAllLogs" />
+    </Button>
+  );
+
   return (
     <Paneset>
       <DataFetcher
@@ -48,6 +60,7 @@ function Home(props) {
               <FormattedMessage id="ui-data-export.logsPaneTitle" />
             </span>
           )}
+          lastMenu={viewAllLogsButton}
         >
           <JobLogsContainer />
         </Pane>

--- a/test/bigtest/interactors/jobs/JobLogsContainerInteractor.js
+++ b/test/bigtest/interactors/jobs/JobLogsContainerInteractor.js
@@ -1,12 +1,14 @@
 import {
   interactor,
   collection,
+  Interactor,
 } from '@bigtest/interactor';
 
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor';
 
 @interactor class JobLogsContainerInteractor {
+  viewAllLogsButton = new Interactor('[data-test-view-all-logs-button]');
   logsList = new MultiColumnListInteractor('#job-logs-list');
   callout = new CalloutInteractor();
   fileNameBtns = collection('[data-test-download-file-btn]');

--- a/test/bigtest/tests/jobLogs-test.js
+++ b/test/bigtest/tests/jobLogs-test.js
@@ -32,6 +32,14 @@ describe('Job logs list', () => {
       expect(jobLogsContainerInteractor.logsList.headers(6).text).to.equal(translations.status);
     });
 
+    it('should display view all logs button', () => {
+      expect(jobLogsContainerInteractor.viewAllLogsButton.isPresent).to.be.true;
+    });
+
+    it('should display correct text on view all logs button', () => {
+      expect(jobLogsContainerInteractor.viewAllLogsButton.text).to.equal(translations.viewAllLogs);
+    });
+
     it('should be sorted by "completedDate" descending by default', () => {
       expect(getCellContent(0, 6)).to.equal('Fail');
       expect(getCellContent(1, 6)).to.equal('Success');

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -3,6 +3,7 @@
   "settings.index.paneTitle": "Data export",
   "jobsPaneTitle": "Jobs",
   "logsPaneTitle": "Logs",
+  "viewAllLogs": "View all",
   "uploaderTitle": "Drag and drop",
   "mappingProfilesTitle": "Field mapping profiles",
   "uploaderBtnText": "or choose file",


### PR DESCRIPTION
## Purposes

Add the "View all" button to the pane header to navigate to the all logs view. [Story](https://issues.folio.org/browse/UIDEXP-62).

The navigation should be implemented in scope of the separated story according to the requirements. 

## Screenshots

![view_all_logs_button](https://user-images.githubusercontent.com/50317804/79337193-be3ac580-7f2d-11ea-9642-c26986823e83.png)

