### PR TITLE
UIDEXP-49: Update jobs list structure according to the accessibility requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Accommodate UI to the change of the export job API endpoint. UIDEXP-44.
 * Handle case when progress field is missing from log detail. UIDEXP-68.
 * Add button to navigate to all logs view. UIDEXP-62.
+* Update jobs list structure according to the accessibility requirements. UIDEXP-49.
 
 ## [1.0.2](https://github.com/folio-org/ui-data-export/tree/v1.0.2) (2020-04-03)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.1...v1.0.2)

--- a/src/components/Jobs/RunningJobs/ItemFormatter/ItemFormatter.css
+++ b/src/components/Jobs/RunningJobs/ItemFormatter/ItemFormatter.css
@@ -1,9 +1,3 @@
-.jobContainer {
-  &:not(:first-child) {
-    margin-top: 10px;
-  }
-}
-
 .buttonsContainer {
   display: flex;
   align-items: center;

--- a/src/components/Jobs/RunningJobs/ItemFormatter/ItemFormatter.js
+++ b/src/components/Jobs/RunningJobs/ItemFormatter/ItemFormatter.js
@@ -9,44 +9,41 @@ import JobDetails from '../JobDetails';
 import css from './ItemFormatter.css';
 
 const ItemFormatter = job => (
-  <div
+  <Job
     key={job.id}
-    className={css.jobContainer}
-    data-test-running-job
+    job={job}
   >
-    <Job job={job}>
-      <JobDetails job={job} />
-      <div
-        data-test-running-job-buttons-container
-        className={css.buttonsContainer}
+    <JobDetails job={job} />
+    <div
+      data-test-running-job-buttons-container
+      className={css.buttonsContainer}
+    >
+      <Button
+        data-test-cancel-job-running
+        buttonStyle="primary"
+        marginBottom0
+        disabled
       >
-        <Button
-          data-test-cancel-job-running
-          buttonStyle="primary"
-          marginBottom0
-          disabled
-        >
-          <FormattedMessage id="ui-data-export.cancel" />
-        </Button>
-        <Button
-          data-test-pause-job-running
-          buttonStyle="primary"
-          marginBottom0
-          disabled
-        >
-          <FormattedMessage id="ui-data-export.pause" />
-        </Button>
-        <Button
-          data-test-resume-job-running
-          buttonStyle="primary"
-          marginBottom0
-          disabled
-        >
-          <FormattedMessage id="ui-data-export.resume" />
-        </Button>
-      </div>
-    </Job>
-  </div>
+        <FormattedMessage id="ui-data-export.cancel" />
+      </Button>
+      <Button
+        data-test-pause-job-running
+        buttonStyle="primary"
+        marginBottom0
+        disabled
+      >
+        <FormattedMessage id="ui-data-export.pause" />
+      </Button>
+      <Button
+        data-test-resume-job-running
+        buttonStyle="primary"
+        marginBottom0
+        disabled
+      >
+        <FormattedMessage id="ui-data-export.resume" />
+      </Button>
+    </div>
+  </Job>
 );
 
 export default ItemFormatter;


### PR DESCRIPTION
## Purpose

Update jobs list structure according to the accessibility requirements in the scope of [UIDEXP-49](https://issues.folio.org/browse/UIDEXP-49).

## Approach

Make sure that immediate children of `<ul>` tags be `<li>` elements.

## Screenshots

### Before
<img width="400" alt="Screen Shot 2020-04-15 at 16 20 28" src="https://user-images.githubusercontent.com/40821852/79342000-41abe500-7f35-11ea-8015-9c21443fe654.png">

### After
<img width="400" alt="Screen Shot 2020-04-15 at 16 19 06" src="https://user-images.githubusercontent.com/40821852/79342005-44a6d580-7f35-11ea-85c8-81f569ee100b.png">