### PR TITLE
UIDEXP-47: Implement mapping profiles form transformation fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 * Mapping profiles list - integation with backend. UIDEXP-57.
 * Add job profiles form. UIDEXP-82.
 * Integrate new mapping profile form with backend. UIDEXP-88.
-* Job profiles list - integation with backend. UIDEXP-81.
+* Job profiles list - integration with backend. UIDEXP-81.
+* Implement mapping profiles form transformation fields. UIDEXP-47.
 
 ## [1.0.2](https://github.com/folio-org/ui-data-export/tree/v1.0.2) (2020-04-03)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.1...v1.0.2)

--- a/package.json
+++ b/package.json
@@ -27,16 +27,15 @@
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes-core": "^5.0.0",
     "@folio/stripes-cli": "^1.11.0",
-    "@folio/stripes-smart-components": "^4.0.0",
     "@folio/stripes": "^4.0.0",
     "@folio/stripes-data-transfer-components": "^1.0.0",
-    "@folio/stripes-final-form": "^2.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
     "eslint": "^6.2.1",
     "eslint-plugin-babel": "^5.3.0",
     "react": "^16.5.0",
+    "react-intl": "^4.5.1",
     "react-dom": "^16.5.0",
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "^0.13.3",
@@ -49,7 +48,8 @@
     "prop-types": "^15.6.0",
     "redux-form": "^7.0.3",
     "react-router-prop-types": "^1.0.4",
-    "react-final-form": "^6.3.5"
+    "react-final-form": "^6.3.5",
+    "react-final-form-arrays": "^3.1.1"
   },
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",

--- a/src/components/QueryFileUploader/QueryFileUploader.js
+++ b/src/components/QueryFileUploader/QueryFileUploader.js
@@ -20,7 +20,7 @@ import {
 import {
   useStripes,
   stripesConnect,
-} from '@folio/stripes-core';
+} from '@folio/stripes/core';
 
 import {
   generateFileDefinitionBody,
@@ -133,7 +133,7 @@ const QueryFileUploaderComponent = props => {
 
     calloutRef.current.sendCallout({
       type: 'error',
-      message: <FormattedMessage id="ui-data-import.communicationProblem" />,
+      message: <FormattedMessage id="ui-data-export.communicationProblem" />,
     });
   };
 

--- a/src/settings/DataExportSettings/DataExportSettings.js
+++ b/src/settings/DataExportSettings/DataExportSettings.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { Settings } from '@folio/stripes/smart-components';
-import { stripesShape } from '@folio/stripes/core';
+import {
+  stripesShape,
+  stripesConnect,
+} from '@folio/stripes/core';
 import {
   ProfilesLabel,
   SettingsLabel,
@@ -30,12 +33,12 @@ const sections = [
       {
         route: 'job-profiles',
         label: getSettingsLabel('jobProfilesTitle', 'jobProfiles'),
-        component: JobProfilesContainer,
+        component: stripesConnect(JobProfilesContainer),
       },
       {
         route: 'mapping-profiles',
         label: getSettingsLabel('mappingProfilesTitle', 'mappingProfiles'),
-        component: MappingProfilesContainer,
+        component: stripesConnect(MappingProfilesContainer),
       },
     ],
   },

--- a/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
+++ b/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
@@ -8,10 +8,7 @@ import {
   location as locationShape,
 } from 'react-router-prop-types';
 
-import {
-  Route,
-  stripesConnect,
-} from '@folio/stripes/core';
+import { Route } from '@folio/stripes/core';
 import { makeQueryFunction } from '@folio/stripes/smart-components';
 import {
   JobProfiles,
@@ -107,4 +104,4 @@ JobProfilesContainer.manifest = Object.freeze({
   },
 });
 
-export default stripesConnect(JobProfilesContainer);
+export default JobProfilesContainer;

--- a/src/settings/JobProfiles/JobProfilesForm/JobProfilesForm.js
+++ b/src/settings/JobProfiles/JobProfilesForm/JobProfilesForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
-  injectIntl,
+  useIntl,
 } from 'react-intl';
 import { noop } from 'lodash';
 import { Field } from 'react-final-form';
@@ -40,8 +40,9 @@ const JobProfilesForm = props => {
     submitting,
     hasLoaded,
     mappingProfiles,
-    intl,
   } = props;
+
+  const intl = useIntl();
 
   return (
     <FormattedMessage id="ui-data-export.mappingProfiles.newProfile">
@@ -117,7 +118,6 @@ JobProfilesForm.propTypes = {
   submitting: PropTypes.bool.isRequired,
   mappingProfiles: PropTypes.arrayOf(PropTypes.object),
   hasLoaded: PropTypes.bool,
-  intl: PropTypes.object.isRequired,
 };
 
 JobProfilesForm.defaultProps = {
@@ -126,7 +126,7 @@ JobProfilesForm.defaultProps = {
   mappingProfiles: [],
 };
 
-export default injectIntl(stripesFinalForm({
+export default stripesFinalForm({
   validate,
   subscription: { values: true },
-})(JobProfilesForm));
+})(JobProfilesForm);

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -25,6 +25,8 @@ import {
   FIND_ALL_CQL,
 } from '../../../utils';
 import { NewMappingProfileFormRoute } from '../NewMappingProfileFormRoute';
+import { generateTransformationFieldsValues } from '../MappingProfilesForm/TransformationsField';
+import { mappingProfileTransformations } from '../MappingProfilesForm/TransformationsField/transformations';
 
 const customProperties = getMappingProfilesColumnProperties({
   columnWidths: { format: '70px' },
@@ -47,6 +49,12 @@ const sortMap = {
   updatedBy: 'userInfo.firstName userInfo.lastName',
 };
 
+const initialValues = {
+  recordTypes: [],
+  outputFormat: 'MARC',
+  transformations: generateTransformationFieldsValues(mappingProfileTransformations),
+};
+
 const MappingProfilesContainer = ({
   history,
   match,
@@ -67,6 +75,7 @@ const MappingProfilesContainer = ({
         render={props => (
           <NewMappingProfileFormRoute
             {...props}
+            initialValues={initialValues}
             onCancel={() => history.push(`${match.path}${location.search}`)}
             onSubmit={mutator.mappingProfiles.POST}
           />

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -7,10 +7,7 @@ import {
   location as locationShape,
 } from 'react-router-prop-types';
 
-import {
-  Route,
-  stripesConnect,
-} from '@folio/stripes/core';
+import { Route } from '@folio/stripes/core';
 import { makeQueryFunction } from '@folio/stripes/smart-components';
 import {
   MappingProfiles,
@@ -119,4 +116,4 @@ MappingProfilesContainer.manifest = Object.freeze({
   },
 });
 
-export default stripesConnect(MappingProfilesContainer);
+export default MappingProfilesContainer;

--- a/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
@@ -53,7 +53,6 @@ export const FolioRecordTypeField = () => {
               type="checkbox"
               value={option.value}
               isEqual={isEqual}
-              initialValue={[]}
               render={fieldProps => {
                 return (
                   <Checkbox

--- a/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
-  injectIntl,
+  useIntl,
 } from 'react-intl';
 import { noop } from 'lodash';
 import { Field } from 'react-final-form';
@@ -44,11 +44,12 @@ const validate = values => {
 const MappingProfilesForm = props => {
   const {
     onCancel,
-    intl,
     handleSubmit,
     pristine,
     submitting,
   } = props;
+
+  const intl = useIntl();
 
   return (
     <FormattedMessage id="ui-data-export.mappingProfiles.newProfile">
@@ -124,14 +125,13 @@ const MappingProfilesForm = props => {
 MappingProfilesForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
-  intl: PropTypes.object.isRequired,
   pristine: PropTypes.bool.isRequired,
   submitting: PropTypes.bool.isRequired,
 };
 
 MappingProfilesForm.defaultProps = { onCancel: noop };
 
-export default injectIntl(stripesFinalForm({
+export default stripesFinalForm({
   validate,
   subscription: { values: true },
-})(MappingProfilesForm));
+})(MappingProfilesForm);

--- a/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
@@ -23,6 +23,7 @@ import stripesFinalForm from '@folio/stripes/final-form';
 import { FullScreenForm } from '@folio/stripes-data-transfer-components';
 
 import { FolioRecordTypeField } from './FolioRecordTypeField/FolioRecordTypeField';
+import { TransformationField } from './TransformationsField';
 import {
   required,
   requiredArray,
@@ -59,9 +60,9 @@ const MappingProfilesForm = props => {
           <FullScreenForm
             id="mapping-profiles-form"
             paneTitle={<FormattedMessage id="ui-data-export.mappingProfiles.newProfile" />}
+            isSubmitButtonDisabled={pristine || submitting}
             onSubmit={handleSubmit}
             onCancel={onCancel}
-            isSubmitButtonDisabled={pristine || submitting}
           >
             <div className={css.mappingProfilesFormContent}>
               <AccordionStatus>
@@ -93,7 +94,6 @@ const MappingProfilesForm = props => {
                           label: intl.formatMessage({ id: 'ui-data-export.marc' }),
                           value: 'MARC',
                         }]}
-                        initialValue="MARC"
                         fullWidth
                         required
                       />
@@ -108,7 +108,9 @@ const MappingProfilesForm = props => {
                       />
                     </div>
                   </Accordion>
-                  <Accordion label={<FormattedMessage id="ui-data-export.transformations" />} />
+                  <Accordion label={<FormattedMessage id="ui-data-export.transformations" />}>
+                    <TransformationField />
+                  </Accordion>
                 </AccordionSet>
               </AccordionStatus>
             </div>
@@ -131,9 +133,5 @@ MappingProfilesForm.defaultProps = { onCancel: noop };
 
 export default injectIntl(stripesFinalForm({
   validate,
-  subscription: {
-    pristine: true,
-    values: true,
-  },
-  initialValues: { folioRecordTypes: [] },
+  subscription: { values: true },
 })(MappingProfilesForm));

--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/TransformationsField.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Field } from 'react-final-form';
+import { FieldArray } from 'react-final-form-arrays';
+import { isEqual } from 'lodash';
+
+import {
+  TextField,
+  MultiColumnList,
+  Layout,
+} from '@folio/stripes/components';
+
+const columnMapping = {
+  fieldName: <FormattedMessage id="ui-data-export.mappingProfiles.transformations.fieldName" />,
+  transformation: <FormattedMessage id="ui-data-export.mappingProfiles.transformations.transformation" />,
+};
+const columnWidths = {
+  fieldName: '45%',
+  transformation: '55%',
+};
+const visibleColumns = ['fieldName', 'transformation'];
+const formatter = {
+  fieldName: record => record.displayName,
+  transformation: record => (
+    <Layout
+      className="full"
+      data-test-transformation-field
+    >
+      <Field
+        key={record.displayName}
+        component={TextField}
+        name={`transformations[${record.order}].transformation`}
+      />
+    </Layout>
+  ),
+};
+
+export const TransformationField = () => {
+  return (
+    <FieldArray
+      name="transformations"
+      isEqual={isEqual}
+    >
+      {({ fields }) => (
+        <MultiColumnList
+          id="mapping-profiles-form-transformations"
+          fields={fields}
+          contentData={fields.value}
+          totalCount={fields.value.length}
+          columnMapping={columnMapping}
+          columnWidths={columnWidths}
+          visibleColumns={visibleColumns}
+          formatter={formatter}
+        />
+      )}
+    </FieldArray>
+  );
+};

--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/TransformationsField.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import { isEqual } from 'lodash';
@@ -10,10 +10,6 @@ import {
   Layout,
 } from '@folio/stripes/components';
 
-const columnMapping = {
-  fieldName: <FormattedMessage id="ui-data-export.mappingProfiles.transformations.fieldName" />,
-  transformation: <FormattedMessage id="ui-data-export.mappingProfiles.transformations.transformation" />,
-};
 const columnWidths = {
   fieldName: '45%',
   transformation: '55%',
@@ -36,6 +32,13 @@ const formatter = {
 };
 
 export const TransformationField = () => {
+  const intl = useIntl();
+
+  const columnMapping = {
+    fieldName: intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.fieldName' }),
+    transformation: intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.transformation' }),
+  };
+
   return (
     <FieldArray
       name="transformations"

--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/index.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/index.js
@@ -1,0 +1,2 @@
+export * from './TransformationsField';
+export * from './processTransformations';

--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/processTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/processTransformations.js
@@ -1,0 +1,20 @@
+import { omit } from 'lodash';
+
+export function generateTransformationFieldsValues(transformations) {
+  return transformations.map((transformation, i) => ({
+    fieldId: transformation.id,
+    path: transformation.path,
+    recordType: transformation.recordType,
+    displayName: transformation.displayName,
+    order: i,
+  }));
+}
+
+export function normalizeTransformationFormValues(transformations) {
+  return transformations
+    .map(transformation => ({
+      ...omit(transformation, 'displayName', 'order'),
+      enabled: Boolean(transformation.transformation),
+    }))
+    .filter(transformation => Boolean(transformation.transformation));
+}

--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/transformations.json
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/transformations.json
@@ -1,0 +1,76 @@
+{
+  "mappingProfileTransformations": [
+    {
+      "id" : "callNumber",
+      "path" : "$.holdings[*].callNumber",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Call number"
+    },
+    {
+      "id" : "callNumberPrefix",
+      "path" : "$.holdings[*].callNumberPrefix",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Call number - prefix"
+    },
+    {
+      "id" : "callNumberSuffix",
+      "path" : "$.holdings[*].callNumberSuffix",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Call number - suffix"
+    },
+    {
+      "id" : "electronicAccess.linkText",
+      "path" : "$.holdings[*].electronicAccess[*].linkTex",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Electronic access - Link text"
+    },
+    {
+      "id" : "electronicAccess.uri",
+      "path" : "$.holdings[*].electronicAccess[*].uri",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Electronic access - URI"
+    },
+    {
+      "id" : "permanentLocationId",
+      "path" : "$.holdings[*].permanentLocationId",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Permanent location"
+    },
+    {
+      "id" : "temporaryLocationId",
+      "path" : "$.holdings[*].temporaryLocationId",
+      "recordType" : "HOLDINGS",
+      "displayName" : "Holdings - Temporary location"
+    },
+    {
+      "id" : "effectiveCallNumberComponents.callNumber",
+      "path" : "$.items[*].effectiveCallNumberComponents.callNumber",
+      "recordType" : "ITEM",
+      "displayName" : "Items - Effective call number"
+    },
+    {
+      "id" : "effectiveLocationId",
+      "path" : "$.items[*].effectiveLocationId",
+      "recordType" : "ITEM",
+      "displayName" : "Items - Effective location"
+    },
+    {
+      "id" : "electronicAccess.linkText",
+      "path" : "$.items[*].electronicAccess[*].linkText",
+      "recordType" : "ITEM",
+      "displayName" : "Items - Electronic access - Link text"
+    },
+    {
+      "id" : "electronicAccess.uri",
+      "path" : "$.items[*].electronicAccess[*].uri",
+      "recordType" : "ITEM",
+      "displayName" : "Items - Electronic access - URI"
+    },
+    {
+      "id" : "materialTypeId",
+      "path" : "$.items[*].materialTypeId",
+      "recordType" : "ITEM",
+      "displayName" : "Items - Material types"
+    }
+  ]
+}

--- a/src/settings/MappingProfiles/NewMappingProfileFormRoute/NewMappingProfileFormRoute.js
+++ b/src/settings/MappingProfiles/NewMappingProfileFormRoute/NewMappingProfileFormRoute.js
@@ -9,12 +9,16 @@ import { MappingProfilesForm } from '../MappingProfilesForm';
 const NewMappingProfileFormRoute = ({
   onSubmit,
   onCancel,
+  initialValues,
 }) => {
   const callout = useContext(CalloutContext);
 
   const handleSubmit = async values => {
     try {
-      await onSubmit(values);
+      await onSubmit({
+        ...values,
+        transformations: [],
+      });
 
       callout.sendCallout({
         message: <SafeHTMLMessage
@@ -29,6 +33,7 @@ const NewMappingProfileFormRoute = ({
 
   return (
     <MappingProfilesForm
+      initialValues={initialValues}
       onSubmit={handleSubmit}
       onCancel={onCancel}
     />
@@ -36,6 +41,7 @@ const NewMappingProfileFormRoute = ({
 };
 
 NewMappingProfileFormRoute.propTypes = {
+  initialValues: PropTypes.object.isRequired,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,6 @@ export const JOB_EXECUTION_STATUSES = {
 
 export const FIND_ALL_CQL = 'cql.allRecords=1';
 
-export const INITIAL_RESULT_COUNT = 5000;
+export const INITIAL_RESULT_COUNT = 100;
 
 export const RESULT_COUNT_INCREMENT = 100;

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -5,10 +5,7 @@ import {
   it,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
-import {
-  noop,
-  isEqual,
-} from 'lodash';
+import { noop } from 'lodash';
 import sinon from 'sinon';
 import { BrowserRouter as Router } from 'react-router-dom';
 
@@ -21,6 +18,22 @@ import stripesComponentsTranslations from '@folio/stripes-components/translation
 import translations from '../../../../../../translations/ui-data-export/en';
 import { MappingProfilesForm } from '../../../../../../src/settings/MappingProfiles/MappingProfilesForm';
 import { MappingProfilesFormInteractor } from './interactors/MappingProfilesFormInteractor';
+
+const initialValues = {
+  recordTypes: [],
+  outputFormat: 'MARC',
+  transformations: [
+    {
+      displayName: 'Transformation field 1',
+      transformation: 'Transformation value 1',
+      order: 0,
+    },
+    {
+      displayName: 'Transformation field 2',
+      order: 1,
+    },
+  ],
+};
 
 describe('MappingProfilesForm', () => {
   const translationsProperties = [
@@ -46,6 +59,7 @@ describe('MappingProfilesForm', () => {
         <Paneset>
           <Router>
             <MappingProfilesForm
+              initialValues={initialValues}
               onSubmit={handleSubmitSpy}
               onCancel={noop}
             />
@@ -97,6 +111,18 @@ describe('MappingProfilesForm', () => {
       expect(form.summary.description.label).to.equal(translations.description);
       expect(form.summary.recordType.label).to.equal(`${commonTranslations.folioRecordType}*`);
       expect(form.summary.outputFormat.label).to.equal(`${translations.outputFormat}*`);
+    });
+
+    it('should display correct transformation fields headers', () => {
+      expect(form.transformations.list.headers(0).text).to.equal(translations['mappingProfiles.transformations.fieldName']);
+      expect(form.transformations.list.headers(1).text).to.equal(translations['mappingProfiles.transformations.transformation']);
+    });
+
+    it('should display correct transformation fields values', () => {
+      expect(form.transformations.list.rows(0).cells(0).text).to.equal('Transformation field 1');
+      expect(form.transformations.valuesFields(0).val).to.equal('Transformation value 1');
+      expect(form.transformations.list.rows(1).cells(0).text).to.equal('Transformation field 2');
+      expect(form.transformations.valuesFields(1).val).to.equal('');
     });
 
     it('should disable save button if there are not changes', () => {
@@ -195,12 +221,14 @@ describe('MappingProfilesForm', () => {
     let result;
     const name = 'Profile name';
     const description = 'Description value';
+    const transformationValue = 'Transformation value 2';
 
     beforeEach(async function () {
       await mountWithContext(
         <Paneset>
           <Router>
             <MappingProfilesForm
+              initialValues={initialValues}
               onSubmit={values => {
                 result = values;
               }}
@@ -212,11 +240,12 @@ describe('MappingProfilesForm', () => {
       );
     });
 
-    describe('filling summary inputs and pressing submit', () => {
+    describe('filling form inputs and pressing submit', () => {
       beforeEach(async () => {
         await form.summary.name.fillAndBlur(name);
         await form.summary.recordType.checkboxes(2).clickInput();
         await form.summary.description.fillAndBlur(description);
+        await form.transformations.valuesFields(1).fillAndBlur(transformationValue);
         await form.fullScreen.submitButton.click();
       });
 
@@ -224,7 +253,14 @@ describe('MappingProfilesForm', () => {
         expect(result.name).to.equal(name);
         expect(result.description).to.equal(description);
         expect(result.outputFormat).to.equal('MARC');
-        expect(isEqual(result.recordTypes, [FOLIO_RECORD_TYPES.ITEM.type])).to.be.true;
+        expect(result.recordTypes).to.deep.equal([FOLIO_RECORD_TYPES.ITEM.type]);
+        expect(result.transformations).to.deep.equal([
+          initialValues.transformations[0],
+          {
+            ...initialValues.transformations[1],
+            transformation: transformationValue,
+          },
+        ]);
       });
     });
   });

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -205,8 +205,8 @@ describe('MappingProfilesForm', () => {
 
         describe('checking and unchecking record type', () => {
           beforeEach(async () => {
-            await await form.summary.recordType.checkboxes(2).clickInput();
-            await await form.summary.recordType.checkboxes(2).clickInput();
+            await form.summary.recordType.checkboxes(2).clickInput();
+            await form.summary.recordType.checkboxes(2).clickInput();
           });
 
           it('should mark field as error and required', () => {

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/MappingProfilesFormInteractor.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/MappingProfilesFormInteractor.js
@@ -5,6 +5,7 @@ import { AccordionSetInteractor } from '@folio/stripes-components/lib/Accordion/
 import { FullScreenFormInteractor } from '@folio/stripes-data-transfer-components/interactors';
 
 import { SummaryContentInteractor } from './SummaryContentInteractor';
+import { TransformationsInteractor } from './TransformationsInteractor';
 
 @interactor
 export class MappingProfilesFormInteractor {
@@ -14,4 +15,5 @@ export class MappingProfilesFormInteractor {
   expandAllButton = new ExpandAllButtonInteractor();
   accordions = new AccordionSetInteractor('#mapping-profiles-form-accordions');
   summary = new SummaryContentInteractor();
+  transformations = new TransformationsInteractor();
 }

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/TransformationsInteractor.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/TransformationsInteractor.js
@@ -1,0 +1,13 @@
+import {
+  interactor,
+  collection,
+} from '@bigtest/interactor';
+
+import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
+import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
+
+@interactor
+export class TransformationsInteractor {
+  list = new MultiColumnListInteractor('#mapping-profiles-form-transformations');
+  valuesFields = collection('#mapping-profiles-form-transformations [data-test-transformation-field]', TextFieldInteractor);
+}

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/mappingProfilesTransformations-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/mappingProfilesTransformations-test.js
@@ -1,0 +1,108 @@
+import {
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import {
+  generateTransformationFieldsValues,
+  normalizeTransformationFormValues,
+} from '../../../../../../src/settings/MappingProfiles/MappingProfilesForm/TransformationsField';
+
+describe('generateTransformationFieldsValues', () => {
+  it('should generate initial transformation values correctly', () => {
+    const data = [
+      {
+        id: 'electronicAccess.uri',
+        path: 'items[*].electronicAccess[*].uri',
+        recordType: 'ITEM',
+        displayName: 'Items - Electronic access - URI',
+      },
+      {
+        id: 'materialTypeId',
+        path: 'items[*].materialTypeId',
+        recordType: 'ITEM',
+        displayName: 'Items - Material types',
+      },
+    ];
+
+    expect(generateTransformationFieldsValues(data)).to.deep.equal(
+      [
+        {
+          fieldId: 'electronicAccess.uri',
+          path: 'items[*].electronicAccess[*].uri',
+          recordType: 'ITEM',
+          displayName: 'Items - Electronic access - URI',
+          order: 0,
+        },
+        {
+          fieldId: 'materialTypeId',
+          path: 'items[*].materialTypeId',
+          recordType: 'ITEM',
+          displayName: 'Items - Material types',
+          order: 1,
+        },
+      ],
+    );
+  });
+});
+
+describe('normalizeTransformationFormValues', () => {
+  const data = [
+    {
+      fieldId: 'electronicAccess.uri',
+      path: 'items[*].electronicAccess[*].uri',
+      recordType: 'ITEM',
+      displayName: 'Items - Electronic access - URI',
+      transformation: 'Transformation value 1',
+      order: 0,
+    },
+    {
+      fieldId: 'materialTypeId',
+      path: 'items[*].materialTypeId',
+      recordType: 'ITEM',
+      displayName: 'Items - Material types',
+      transformation: 'Transformation value 2',
+      order: 1,
+    },
+  ];
+
+  it('should normalize transformation values correctly', () => {
+    expect(normalizeTransformationFormValues(data)).to.deep.equal(
+      [
+        {
+          fieldId: 'electronicAccess.uri',
+          path: 'items[*].electronicAccess[*].uri',
+          recordType: 'ITEM',
+          transformation: 'Transformation value 1',
+          enabled: true,
+        },
+        {
+          fieldId: 'materialTypeId',
+          path: 'items[*].materialTypeId',
+          recordType: 'ITEM',
+          transformation: 'Transformation value 2',
+          enabled: true,
+        },
+      ],
+    );
+  });
+
+  it('should filter out items with empty transformation field', () => {
+    const modifiedData = data.map(item => ({ ...item }));
+
+    delete modifiedData[0].transformation;
+
+    expect(normalizeTransformationFormValues(modifiedData)).to.deep.equal(
+      [
+        {
+          fieldId: 'materialTypeId',
+          path: 'items[*].materialTypeId',
+          recordType: 'ITEM',
+          transformation: 'Transformation value 2',
+          enabled: true,
+        },
+      ],
+    );
+  });
+});

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -37,6 +37,8 @@
   "protocol": "TCP/IP",
   "mappingProfile": "Mapping profile",
   "mappingProfiles.newProfile": "New field mapping profile",
+  "mappingProfiles.transformations.fieldName": "Field name",
+  "mappingProfiles.transformations.transformation": "Transformation",
   "jobProfiles.newProfile": "New job profile",
   "selectMappingProfile": "Select mapping profile",
   "mappingProfiles.createdCallout": "Field mapping profile <b>{name}</b> has been successfully <b>created</b>",


### PR DESCRIPTION
## Purpose

Implement mapping profiles form transformation fields in the scope of the [UIDEXP-47](https://issues.folio.org/browse/UIDEXP-47).

## Approach

`FieldArray` from `react-final-form-arrays` in conjunction with MCL. Filed operates with `order` prop to be able in the future to do sorting and searching properly. Fields such as `order` and `displayName` should eventually be removed before sending a request to the server. `normalizeTransformationFormValues` should be used for that.

## Screenshot

<img width="770" alt="Screen Shot 2020-05-29 at 15 14 59" src="https://user-images.githubusercontent.com/40821852/83258768-8f1ba300-a1bf-11ea-9b50-2fac82b6f9cc.png">
