### PR TITLE
UIDEXP-97: Add Error column to the list of completed jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Integrate new mapping profile form with backend. UIDEXP-88.
 * Job profiles list - integration with backend. UIDEXP-81.
 * Implement mapping profiles form transformation fields. UIDEXP-47.
+* Add Error column to the list of completed jobs. UIDEXP-97.
 
 ## [1.0.2](https://github.com/folio-org/ui-data-export/tree/v1.0.2) (2020-04-03)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.1...v1.0.2)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -12,6 +12,7 @@ import {
   defaultJobLogsVisibleColumns,
   defaultJobLogsSortColumns,
   sortStrings,
+  sortNumbers,
 } from '@folio/stripes-data-transfer-components';
 import {
   Button,
@@ -34,19 +35,19 @@ import styles from './jobLogsContainer.css';
 
 const sortColumns = {
   ...defaultJobLogsSortColumns,
+  errors: {
+    sortFn: sortNumbers,
+    useFormatterFn: true,
+  },
   status: {
     sortFn: sortStrings,
     useFormatterFn: true,
   },
 };
 
-const columnMapping = {
-  ...defaultJobLogsColumnMapping,
-  status: <FormattedMessage id="ui-data-export.status" />,
-};
-
 const visibleColumns = [
   ...defaultJobLogsVisibleColumns,
+  'errors',
   'status',
 ];
 
@@ -106,12 +107,21 @@ const JobLogsContainer = props => {
       {intl => (
         <>
           <JobLogs
-            columnMapping={columnMapping}
+            columnMapping={{
+              ...defaultJobLogsColumnMapping,
+              errors: intl.formatMessage({ id: 'ui-data-export.errors' }),
+              status: intl.formatMessage({ id: 'ui-data-export.status' }),
+            }}
             formatter={getJobLogsItemFormatter(
               {
                 status: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${record.status.toLowerCase()}` }),
                 fileName: record => getFileNameField(record),
                 jobProfileName: record => get(record, 'jobProfileName.name', 'default'),
+                errors: record => {
+                  const { progress: { failed } } = record;
+
+                  return failed || '';
+                },
               },
             )}
             visibleColumns={visibleColumns}

--- a/test/bigtest/network/scenarios/fetch-job-executions-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-executions-success.js
@@ -27,7 +27,11 @@ export const logJobExecutions = [
   },
   {
     hrId: 3,
-    progress: { total: 5000 },
+    progress: {
+      exported: 4990,
+      failed: 10,
+      total: 5000,
+    },
     runBy: {
       firstName: 'Elliot',
       lastName: 'Lane',

--- a/test/bigtest/tests/jobLogs-test.js
+++ b/test/bigtest/tests/jobLogs-test.js
@@ -30,7 +30,7 @@ describe('Job logs list', () => {
     });
 
     it('should add status column to the end', () => {
-      expect(jobLogsContainerInteractor.logsList.headers(6).text).to.equal(translations.status);
+      expect(jobLogsContainerInteractor.logsList.headers(7).text).to.equal(translations.status);
     });
 
     it('should display view all logs button', () => {
@@ -57,8 +57,8 @@ describe('Job logs list', () => {
     });
 
     it('should be sorted by "completedDate" descending by default', () => {
-      expect(getCellContent(0, 6)).to.equal('Success');
-      expect(getCellContent(1, 6)).to.equal('Fail');
+      expect(getCellContent(0, 7)).to.equal('Success');
+      expect(getCellContent(1, 7)).to.equal('Fail');
     });
 
     it('should render ID column', () => {
@@ -71,6 +71,10 @@ describe('Job logs list', () => {
 
     it('should render run by user column', () => {
       expect(jobLogsContainerInteractor.logsList.headers(5).text).to.equal(commonTranslations.runBy);
+    });
+
+    it('should render errors column', () => {
+      expect(jobLogsContainerInteractor.logsList.headers(6).text).to.equal(translations.errors);
     });
 
     it('should populate ID cells correctly', () => {
@@ -88,13 +92,18 @@ describe('Job logs list', () => {
       expect(getCellContent(1, 5)).to.equal(`${getUser(0).firstName} ${getUser(0).lastName}`);
     });
 
+    it('should populate errors cells correctly', () => {
+      expect(getCellContent(0, 6)).to.equal('10');
+      expect(getCellContent(1, 6)).to.equal('');
+    });
+
     describe('clicking on status header', () => {
       beforeEach(async () => {
-        await jobLogsContainerInteractor.logsList.headers(6).click();
+        await jobLogsContainerInteractor.logsList.headers(7).click();
       });
 
       it('should sort by status in ascending order', () => {
-        expect(getCellContent(1, 6)).to.equal('Success');
+        expect(getCellContent(1, 7)).to.equal('Success');
       });
 
       it('should have the correct query in path', function () {
@@ -103,12 +112,12 @@ describe('Job logs list', () => {
 
       describe('clicking on status header', () => {
         beforeEach(async () => {
-          await jobLogsContainerInteractor.logsList.headers(6).click();
+          await jobLogsContainerInteractor.logsList.headers(7).click();
         });
 
         it('should sort by status in descending order', () => {
-          expect(getCellContent(1, 6)).to.equal('Fail');
-          expect(getCellContent(0, 6)).to.equal('Success');
+          expect(getCellContent(1, 7)).to.equal('Fail');
+          expect(getCellContent(0, 7)).to.equal('Success');
         });
 
         it('should have the correct query in path', function () {

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -26,6 +26,7 @@
   "outputFormat": "Output format",
   "transformations": "Transformations",
   "uploading": "Uploading",
+  "errors": "Errors",
   "status": "Status",
   "jobStatus.fail": "Fail",
   "jobStatus.success": "Success",


### PR DESCRIPTION
## Description

Add 'Errors' column to the list of completed jobs on the main page

## Issue

[UIDEXP-97](https://issues.folio.org/browse/UIDEXP-97)

## Screenshot

![image](https://user-images.githubusercontent.com/55701515/83498920-369d1c00-a4c5-11ea-9a09-03c61621cf11.png)
