### PR TITLE
UIDEXP-47: Provide correct mapping transformations path for "electronicAccess.linkText"

### DIFF
--- a/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/transformations.json
+++ b/src/settings/MappingProfiles/MappingProfilesForm/TransformationsField/transformations.json
@@ -20,7 +20,7 @@
     },
     {
       "id" : "electronicAccess.linkText",
-      "path" : "$.holdings[*].electronicAccess[*].linkTex",
+      "path" : "$.holdings[*].electronicAccess[*].linkText",
       "recordType" : "HOLDINGS",
       "displayName" : "Holdings - Electronic access - Link text"
     },


### PR DESCRIPTION
## Purpose

Provide correct mapping transformations path for "electronicAccess.linkText" in the scope of [UIDEXP-47](https://issues.folio.org/browse/UIDEXP-47).