### PR TITLE
UIDEXP-107: Fix error screen display in case of missed user information in job executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-data-export
 
 ## 2.1.0 (IN PROGRESS)
+* Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
+++ b/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
@@ -35,10 +35,7 @@ const JobDetails = props => {
     jobProfileInfo,
     exportedFiles,
     hrId,
-    runBy: {
-      firstName,
-      lastName,
-    },
+    runBy,
     progress: {
       total,
       exported,
@@ -55,12 +52,16 @@ const JobDetails = props => {
       </div>
       <div className={css.delimiter}>
         <span data-test-running-job-hr-id>{hrId}</span>
-        <span data-test-running-job-triggered-by>
-          <FormattedMessage
-            id="ui-data-export.triggeredBy"
-            values={{ userName: `${firstName} ${lastName}` }}
-          />
-        </span>
+        {runBy &&
+          (
+            <span data-test-running-job-triggered-by>
+              <FormattedMessage
+                id="ui-data-export.triggeredBy"
+                values={{ userName: `${runBy.firstName} ${runBy.lastName}` }}
+              />
+            </span>
+          )
+        }
       </div>
       <div className={css.delimiter}>
         <span data-test-running-job-date-label>

--- a/test/bigtest/interactors/jobs/RunningJobsInteractor.js
+++ b/test/bigtest/interactors/jobs/RunningJobsInteractor.js
@@ -4,6 +4,7 @@ import {
   scoped,
   collection,
   count,
+  Interactor,
 } from '@bigtest/interactor';
 
 import { ProgressInteractor } from '@folio/stripes-data-transfer-components/interactors';
@@ -16,7 +17,7 @@ class JobInteractor {
   fileName = text('[data-test-running-job-file-name]');
   hrId = text('[data-test-running-job-hr-id]');
   status = text('[data-test-running-job-progress-status]');
-  triggeredBy = text('[data-test-running-job-triggered-by]');
+  triggeredBy = new Interactor('[data-test-running-job-triggered-by]');
   buttons = scoped('[data-test-running-job-buttons-container]', RunningJobsControlButtonsInteractor);
   progress = scoped('[data-test-progress-bar]', ProgressInteractor);
 

--- a/test/bigtest/network/scenarios/fetch-job-executions-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-executions-success.js
@@ -21,6 +21,7 @@ export const runningJobExecutions = [
       exported: 10,
       total: 100,
     },
+    runBy: null,
     status: 'IN_PROGRESS',
     startedDate: '2020-01-27T10:09:18.743+0000',
   },

--- a/test/bigtest/tests/jobs-test.js
+++ b/test/bigtest/tests/jobs-test.js
@@ -71,13 +71,18 @@ describe('Jobs lists', () => {
       expect(runningJobs.jobItems(0).hrId).to.equal(String(runningJobExecution.hrId));
     });
 
-    it('should display correct triggered by name', () => {
+    it('should display correct triggered by name for existing user information', () => {
       const {
         firstName,
         lastName,
       } = runningJobExecution.runBy;
 
-      expect(runningJobs.jobItems(0).triggeredBy).to.equal(`Triggered by ${firstName} ${lastName}`);
+      expect(runningJobs.jobItems(0).triggeredBy.isPresent).to.be.true;
+      expect(runningJobs.jobItems(0).triggeredBy.text).to.equal(`Triggered by ${firstName} ${lastName}`);
+    });
+
+    it('should not display triggered by message in case of missed user information', () => {
+      expect(runningJobs.jobItems(1).triggeredBy.isPresent).to.be.false;
     });
 
     it('should display job profile name', () => {


### PR DESCRIPTION
## Purposes

The user info can't be provided in some cases according to the latests information. So the check is added to prevent the main page crashing and updated tests. [Issue](https://issues.folio.org/browse/UIDEXP-107).