### PR TITLE
UIDEXP-53: Update description and link in profiles info on the second settings pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
+* Update description and link in profiles info on the second settings pane. UIDEXP-53.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/settings/DataExportSettings/DataExportSettings.js
+++ b/src/settings/DataExportSettings/DataExportSettings.js
@@ -26,8 +26,8 @@ const getSettingsLabel = (messageId, iconKey) => {
 const sections = [
   {
     label: <ProfilesLabel
-      link="https://wiki.folio.org/display/FOLIOtips/Creating+and+using+profiles"
-      content={<div style={{ width: '150px' }} />}
+      link="https://wiki.folio.org/x/AyUuAg"
+      content={<FormattedMessage id="ui-data-export.settings.profilesInfo" />}
     />,
     pages: [
       {

--- a/test/bigtest/interactors/settings/SettingsSectionsPaneInteractor.js
+++ b/test/bigtest/interactors/settings/SettingsSectionsPaneInteractor.js
@@ -1,11 +1,16 @@
 import {
   interactor,
-  Interactor,
   collection,
 } from '@bigtest/interactor';
 
+import {
+  ProfilesPopoverInteractor,
+  ProfilesLabelInteractor,
+} from '@folio/stripes-data-transfer-components/interactors';
+
 @interactor class SettingsSectionsPaneInteractor {
-  profilesLabel = new Interactor('[data-test-profile-label]');
+  profilesLabel = new ProfilesLabelInteractor();
+  profilesPopover = new ProfilesPopoverInteractor();
   sectionsLabels = collection('[data-test-settings-label] [class*=label--]');
   navigationItems = collection('[class*=pane--]:nth-child(2) [data-test-nav-list-item]');
 }

--- a/test/bigtest/tests/settings-test.js
+++ b/test/bigtest/tests/settings-test.js
@@ -30,6 +30,28 @@ describe('Settings', () => {
     expect(settingsSectionsPane.profilesLabel.isPresent).to.be.true;
   });
 
+  it('should not display profiles inform popover', () => {
+    expect(settingsSectionsPane.profilesPopover.isPresent).to.be.false;
+  });
+
+  describe('clicking on inform button from profiles label', () => {
+    beforeEach(async () => {
+      await settingsSectionsPane.profilesLabel.infoButton.click();
+    });
+
+    it('should display profiles inform popover', () => {
+      expect(settingsSectionsPane.profilesPopover.isPresent).to.be.true;
+    });
+
+    it('should display correct message in inform popover', () => {
+      expect(settingsSectionsPane.profilesPopover.content.text).to.equal(translations['settings.profilesInfo']);
+    });
+
+    it('should have correct link in learn more button', () => {
+      expect(settingsSectionsPane.profilesPopover.linkHref).to.equal('https://wiki.folio.org/x/AyUuAg');
+    });
+  });
+
   it('should display section labels', () => {
     expect(settingsSectionsPane.sectionsLabels(0).isPresent).to.be.true;
   });

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -52,5 +52,6 @@
   "mappingProfiles.errorCallout": "There was an error while creating the field mapping profile <b>{name}</b>",
   "jobProfiles.createdCallout": "Job profile <b>{name}</b> has been successfully <b>created</b>",
   "jobProfiles.errorCallout": "There was an error while creating the job profile <b>{name}</b>",
-  "marc": "MARC"
+  "marc": "MARC",
+  "settings.profilesInfo": "The data export profiles add flexibility and provide an easy way to configure export that is repeatable and can be easily executed on different data sets."
 }


### PR DESCRIPTION
## Purposes

Add a description to the profiles info and update link to the data export specific page. [Story](https://issues.folio.org/browse/UIDEXP-53)

## Screenshots

![Screen Shot 2020-06-17 at 2 20 39 PM](https://user-images.githubusercontent.com/50317804/84892437-419ba300-b0a6-11ea-934d-899f838bcc3a.png)
