### PR TITLE
UIDEXP-109: Display user name while viewing the mapping profile summary accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 * Update description and link in profiles info on the second settings pane. UIDEXP-53.
+* Display user name while viewing the mapping profile summary accordion. UIDEXP-115.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
@@ -16,11 +16,11 @@ import {
   KeyValue,
   Layer,
   List,
-  MetaSection,
   MultiColumnList,
   NoValue,
   Row,
 } from '@folio/stripes/components';
+import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
   FOLIO_RECORD_TYPES,
   FullScreenView,
@@ -45,6 +45,7 @@ const formatter = {
 const MappingProfileDetails = props => {
   const {
     onCancel,
+    stripes,
     mappingProfile: {
       hasLoaded,
       records,
@@ -97,11 +98,9 @@ const MappingProfileDetails = props => {
                   </Row>
                   <AccordionSet id="mapping-profile-details-accordions">
                     <Accordion label={<FormattedMessage id="ui-data-export.summary" />}>
-                      <MetaSection
-                        createdBy={record.metadata.createdByUserId}
-                        lastUpdatedBy={record.metadata.updatedByUserId}
-                        createdDate={record.metadata.createdDate}
-                        lastUpdatedDate={record.metadata.updatedDate}
+                      <ViewMetaData
+                        metadata={record.metadata}
+                        stripes={stripes}
                       />
                       <Row>
                         <Col xs>
@@ -177,6 +176,7 @@ const MappingProfileDetails = props => {
 MappingProfileDetails.propTypes = {
   onCancel: PropTypes.func,
   mappingProfile: mappingProfilesShape,
+  stripes: PropTypes.object,
 };
 
 MappingProfileDetails.defaultProps = {

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
@@ -23,6 +23,15 @@ import {
 
 describe('MappingProfileDetails', () => {
   const mappingProfileDetails = new MappingProfileDetailsInteractor();
+  const stripes = {
+    connect: Component => props => (
+      <Component
+        {... props}
+        mutator={{}}
+        resources={{}}
+      />
+    ),
+  };
 
   describe('rendering mapping profile details', function () {
     beforeEach(async function () {
@@ -30,6 +39,7 @@ describe('MappingProfileDetails', () => {
         <Paneset>
           <Router>
             <MappingProfileDetails
+              stripes={stripes}
               mappingProfile={{
                 hasLoaded: true,
                 records: [mappingProfileWithTransformations],
@@ -109,6 +119,7 @@ describe('MappingProfileDetails', () => {
         <Paneset>
           <Router>
             <MappingProfileDetails
+              stripes={stripes}
               mappingProfile={{
                 hasLoaded: true,
                 records: [mappingProfile],
@@ -136,6 +147,7 @@ describe('MappingProfileDetails', () => {
         <Paneset>
           <Router>
             <MappingProfileDetails
+              stripes={stripes}
               mappingProfile={{
                 hasLoaded: false,
                 records: [],


### PR DESCRIPTION
## Purpose

Display user name while viewing the mapping profile summary accordion in the scope of the [UIDEXP-109](https://issues.folio.org/browse/UIDEXP-115).