### PR TITLE
UIDEXP-76: Add translations for permission names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
-* Update description and link in profiles info on the second settings pane. UIDEXP-53.
+* Update description and link in profiles info on the second setting's pane. UIDEXP-53.
 * Display user name while viewing the mapping profile summary accordion. UIDEXP-115.
+* Add translations for permission names. UIDEXP-76.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -90,6 +90,13 @@
           "data-export.job-profiles.collection.get",
           "data-export.job-profiles.item.post"
         ],
+        "visible": false
+      },
+      {
+        "permissionName": "ui-data-export.app.enabled",
+        "subPermissions": [
+          "module.data-export.enabled"
+        ],
         "visible": true
       },
       {
@@ -97,6 +104,13 @@
         "displayName": "Settings (data-export): display list of settings pages",
         "subPermissions": [
           "settings.enabled"
+        ],
+        "visible": false
+      },
+      {
+        "permissionName": "ui-data-export.settings.enabled",
+        "subPermissions": [
+          "settings.data-export.enabled"
         ],
         "visible": true
       }

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -1,6 +1,10 @@
 {
   "meta.title": "Data export",
   "settings.index.paneTitle": "Data export",
+
+  "permission.app.enabled": "UI: Data export module is enabled",
+  "permission.settings.enabled": "Settings (data-export): display list of settings pages",
+
   "jobsPaneTitle": "Jobs",
   "logsPaneTitle": "Logs",
   "viewAllLogs": "View all",


### PR DESCRIPTION
## Purpose

Add translations for permission names in the scope of the [UIDEXP-76](https://issues.folio.org/browse/UIDEXP-76).