### PR TITLE
UIDEXP-118: Fix transformation labels display on mapping details view page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update description and link in profiles info on the second setting's pane. UIDEXP-53.
 * Display user name while viewing the mapping profile summary accordion. UIDEXP-115.
 * Add translations for permission names. UIDEXP-76.
+* Fix transformation labels display on mapping details view page. UIDEXP-118.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
@@ -38,7 +38,7 @@ const columnWidths = {
 };
 const visibleColumns = ['fieldName', 'transformation'];
 const formatter = {
-  fieldName: record => mappingProfileTransformations.find(({ id }) => id === record.fieldId).displayName,
+  fieldName: record => mappingProfileTransformations.find(({ path }) => path === record.path).displayName,
   transformation: record => record.transformation,
 };
 

--- a/test/bigtest/tests/settings-test.js
+++ b/test/bigtest/tests/settings-test.js
@@ -3,7 +3,10 @@ import {
   describe,
   beforeEach,
   it,
+  afterEach,
 } from '@bigtest/mocha';
+
+import { wait } from '@folio/stripes-data-transfer-components/interactors';
 
 import { setupApplication } from '../helpers';
 import {
@@ -32,24 +35,6 @@ describe('Settings', () => {
 
   it('should not display profiles inform popover', () => {
     expect(settingsSectionsPane.profilesPopover.isPresent).to.be.false;
-  });
-
-  describe('clicking on inform button from profiles label', () => {
-    beforeEach(async () => {
-      await settingsSectionsPane.profilesLabel.infoButton.click();
-    });
-
-    it('should display profiles inform popover', () => {
-      expect(settingsSectionsPane.profilesPopover.isPresent).to.be.true;
-    });
-
-    it('should display correct message in inform popover', () => {
-      expect(settingsSectionsPane.profilesPopover.content.text).to.equal(translations['settings.profilesInfo']);
-    });
-
-    it('should have correct link in learn more button', () => {
-      expect(settingsSectionsPane.profilesPopover.linkHref).to.equal('https://wiki.folio.org/x/AyUuAg');
-    });
   });
 
   it('should display section labels', () => {
@@ -81,6 +66,29 @@ describe('Settings', () => {
 
     it('should navigate to job profiles section', function () {
       expect(this.location.pathname.endsWith('job-profiles')).to.be.true;
+    });
+  });
+
+  describe('clicking on inform button from profiles label', () => {
+    beforeEach(async () => {
+      await settingsSectionsPane.profilesLabel.infoButton.click();
+    });
+
+    afterEach(async () => {
+      await settingsSectionsPane.profilesLabel.infoButton.click();
+      await wait();
+    });
+
+    it('should display profiles inform popover', () => {
+      expect(settingsSectionsPane.profilesPopover.isPresent).to.be.true;
+    });
+
+    it('should display correct message in inform popover', () => {
+      expect(settingsSectionsPane.profilesPopover.content.text).to.equal(translations['settings.profilesInfo']);
+    });
+
+    it('should have correct link in learn more button', () => {
+      expect(settingsSectionsPane.profilesPopover.linkHref).to.equal('https://wiki.folio.org/x/AyUuAg');
     });
   });
 });


### PR DESCRIPTION
## Purposes

Use path instead of id for transformations search to fix labels display. [Issue](https://issues.folio.org/browse/UIDEXP-118)

Additionally I handled issue with broken unit tests.