### PR TITLE
UIDEXP-121: Add long file names handling in job logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Display user name while viewing the mapping profile summary accordion. UIDEXP-115.
 * Add translations for permission names. UIDEXP-76.
 * Fix transformation labels display on mapping details view page. UIDEXP-118.
+* Add long file names handling in job logs. UIDEXP-121.
+* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^6.2.1",
     "eslint-plugin-babel": "^5.3.0",
     "react": "^16.5.0",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "react-dom": "^16.5.0",
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "^0.13.3",
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "@folio/react-intl-safe-html": "^2.0.0",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -11,6 +11,7 @@ import {
   defaultJobLogsColumnMapping,
   defaultJobLogsVisibleColumns,
   defaultJobLogsSortColumns,
+  defaultJobLogsColumnWidths,
   sortStrings,
   sortNumbers,
 } from '@folio/stripes-data-transfer-components';
@@ -47,6 +48,11 @@ const visibleColumns = [
   'errors',
   'status',
 ];
+
+const columnWidths = {
+  ...defaultJobLogsColumnWidths,
+  fileName: '450px',
+};
 
 // TODO: remove formatter for jobProfileName once backend is in place
 const JobLogsContainer = props => {
@@ -121,6 +127,7 @@ const JobLogsContainer = props => {
               },
             )}
             visibleColumns={visibleColumns}
+            columnWidths={columnWidths}
             sortColumns={sortColumns}
             hasLoaded={hasLoaded}
             contentData={logs}

--- a/src/components/JobLogsContainer/jobLogsContainer.css
+++ b/src/components/JobLogsContainer/jobLogsContainer.css
@@ -2,4 +2,16 @@
   margin-top: 0.25rem !important;
   margin-bottom: 0.25rem !important;
   color: inherit !important;
+  padding: 0.25em 10px !important;
+
+  &::before {
+    border-radius: 6px;
+  }
+}
+
+.fileNameBtn span {
+  white-space: normal;
+  width: 100%;
+  text-align: left;
+  word-break: break-all;
 }


### PR DESCRIPTION
## Purposes

The next changes were added to handle long file names in job logs ([Story](https://issues.folio.org/browse/UIDEXP-121)):
- moved to the static size of the "File name" column (it was agreed with @VictorSoroka1)
- changed button border radius 
- updated labels' settings to support long files name in job logs

**Note**: I have to update react-intl version to avoid broken changes https://github.com/formatjs/formatjs/issues/1744.

## Screenshots

![Screen Shot 2020-06-23 at 12 35 03 PM](https://user-images.githubusercontent.com/50317804/85390106-017a6b80-b551-11ea-82f5-07377b2f4d4c.png)

![Screen Shot 2020-06-23 at 12 35 09 PM](https://user-images.githubusercontent.com/50317804/85390116-03442f00-b551-11ea-8a6a-4055cf3e3762.png)
