### PR TITLE
UIDEXP-123: Fix drag and drop area translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add translations for permission names. UIDEXP-76.
 * Fix transformation labels display on mapping details view page. UIDEXP-118.
 * Add long file names handling in job logs. UIDEXP-121.
-* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.
+* Fix drag and drop area translation. UIDEXP-123.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^6.2.1",
     "eslint-plugin-babel": "^5.3.0",
     "react": "^16.5.0",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.7.2",
     "react-dom": "^16.5.0",
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "^0.13.3",
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "@folio/react-intl-safe-html": "^2.0.0",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.7.2",
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -89,7 +89,9 @@ const JobLogsContainer = props => {
   const getFileNameField = record => {
     const fileName = get(record.exportedFiles, '0.fileName');
 
-    if (!record.progress.exported) return fileName;
+    if (!record.progress.exported) {
+      return <span className={styles.disabledFileName}>{fileName}</span>;
+    }
 
     return (
       <Button

--- a/src/components/JobLogsContainer/jobLogsContainer.css
+++ b/src/components/JobLogsContainer/jobLogsContainer.css
@@ -15,3 +15,7 @@
   text-align: left;
   word-break: break-all;
 }
+
+.disabledFileName {
+  padding: 0.25em 10px !important;
+}

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -13,7 +13,7 @@
   "jobProfilesTitle": "Job profiles",
   "uploaderBtnText": "or choose file",
   "uploaderSubTitle": "Select a file with records IDs or CQL queries",
-  "uploaderActiveTitle": "Drop to start import",
+  "uploaderActiveTitle": "Drop to start export",
   "runningJobs": "Running",
   "triggeredBy": "Triggered by {userName}",
   "jobProfileLabel": "Job profile: {jobProfile}",


### PR DESCRIPTION
## Purposes

Update translation of the drag and drop area. [Issue
](https://issues.folio.org/browse/UIDEXP-123)
**Additional changes:** 
- Fix file name (disabled case) padding in job logs
- Unpin react-intl version according to broken changes fixing in 4.7.2
