### PR TITLE
UIDEXP-116: Add job name display in job logs and executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix transformation labels display on mapping details view page. UIDEXP-118.
 * Add long file names handling in job logs. UIDEXP-121.
 * Fix drag and drop area translation. UIDEXP-123.
+* Add job name display in job logs and executions. UIDEXP-116.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -120,7 +120,6 @@ const JobLogsContainer = props => {
               {
                 status: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${record.status.toLowerCase()}` }),
                 fileName: record => getFileNameField(record),
-                jobProfileName: record => get(record, 'jobProfileName.name', 'default'),
                 errors: record => {
                   const { progress: { failed } } = record;
 

--- a/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
+++ b/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
@@ -27,12 +27,11 @@ const formatTime = dateStr => {
   return <span>{datePart} {timePart} {todayPart}</span>;
 };
 
-// TODO: remove defaults for jobProfileInfo once backend is in place
 const JobDetails = props => {
   const { job } = props;
 
   const {
-    jobProfileInfo,
+    jobProfileName,
     exportedFiles,
     hrId,
     runBy,
@@ -47,7 +46,7 @@ const JobDetails = props => {
   return (
     <>
       <div className={classNames(css.delimiter, css.jobHeader)}>
-        <span data-test-running-job-profile>{get(jobProfileInfo, 'name', 'default')}</span>
+        <span data-test-running-job-profile>{jobProfileName}</span>
         <span data-test-running-job-file-name>{get(exportedFiles, '0.fileName')}</span>
       </div>
       <div className={css.delimiter}>

--- a/test/bigtest/network/factories/job-execution.js
+++ b/test/bigtest/network/factories/job-execution.js
@@ -24,10 +24,8 @@ export default Factory.extend({
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
   }),
-  jobProfileInfo: () => ({
-    id: faker.random.uuid(),
-    name: 'default',
-  }),
+  jobProfileId: faker.random.uuid(),
+  jobProfileName: 'default',
   progress: () => {
     const total = faker.random.number({ max: 1000 });
 

--- a/test/bigtest/network/scenarios/fetch-job-executions-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-executions-success.js
@@ -1,7 +1,7 @@
 export const runningJobExecutions = [
   {
     hrId: 0,
-    jobProfileInfo: { name: 'default' },
+    jobProfileName: 'default',
     exportedFiles: [{ fileName: 'import-0.mrc' }],
     runBy: {
       firstName: 'John',

--- a/test/bigtest/tests/jobs-test.js
+++ b/test/bigtest/tests/jobs-test.js
@@ -50,7 +50,7 @@ describe('Jobs lists', () => {
     });
 
     it('should display correct job profile name', () => {
-      expect(runningJobs.jobItems(0).jobProfileName).to.equal(runningJobExecution.jobProfileInfo.name);
+      expect(runningJobs.jobItems(0).jobProfileName).to.equal(runningJobExecution.jobProfileName);
     });
 
     it('should display correct file name', () => {


### PR DESCRIPTION
## Purposes

Add job name display in job logs and executions. [Story](https://issues.folio.org/browse/UIDEXP-116)
Updated tests according to changes in backend responses format

## Screenshots

![Screen Shot 2020-06-25 at 12 52 56 PM](https://user-images.githubusercontent.com/50317804/85711385-e5610080-b6ef-11ea-9838-8cb4e7eb483e.png)
