### PR TITLE
UIDEXP-84: Implement job profile details actions menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix drag and drop area translation. UIDEXP-123.
 * Add job name display in job logs and executions. UIDEXP-116.
 * Implement job profile details page. UIDEXP-86.
+* Implement job profile details action menu. UIDEXP-84.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
+++ b/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -19,6 +19,7 @@ import {
   Preloader,
   SettingsLabel,
 } from '@folio/stripes-data-transfer-components';
+import { JobProfileDetailsActionMenu } from '../JobProfileDetailsActionMenu';
 
 const JobProfileDetails = props => {
   const {
@@ -26,8 +27,18 @@ const JobProfileDetails = props => {
     mappingProfile,
     isLoading,
     stripes,
+    isProfileAlreadyInUse,
     onCancel,
   } = props;
+
+  const renderActionMenu = useCallback(({ onToggle }) => {
+    return (
+      <JobProfileDetailsActionMenu
+        isProfileAlreadyInUse={isProfileAlreadyInUse}
+        onToggle={onToggle}
+      />
+    );
+  }, [isProfileAlreadyInUse]);
 
   return (
     <FormattedMessage id="ui-data-export.mappingProfiles.newProfile">
@@ -39,6 +50,7 @@ const JobProfileDetails = props => {
           <FullScreenView
             id="job-profile-details"
             paneTitle={jobProfile?.name && <SettingsLabel iconKey="jobProfiles">{jobProfile.name}</SettingsLabel>}
+            actionMenu={!isLoading && renderActionMenu}
             onCancel={onCancel}
           >
             {isLoading
@@ -112,6 +124,7 @@ const JobProfileDetails = props => {
 };
 
 JobProfileDetails.propTypes = {
+  isProfileAlreadyInUse: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   mappingProfile: PropTypes.object,
   jobProfile: PropTypes.object,

--- a/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
+++ b/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
@@ -27,18 +27,20 @@ const JobProfileDetails = props => {
     mappingProfile,
     isLoading,
     stripes,
-    isProfileAlreadyInUse,
+    isProfileUsed,
+    isDefaultProfile,
     onCancel,
   } = props;
 
   const renderActionMenu = useCallback(({ onToggle }) => {
     return (
       <JobProfileDetailsActionMenu
-        isProfileAlreadyInUse={isProfileAlreadyInUse}
+        isProfileUsed={isProfileUsed}
+        isDefaultProfile={isDefaultProfile}
         onToggle={onToggle}
       />
     );
-  }, [isProfileAlreadyInUse]);
+  }, [isProfileUsed, isDefaultProfile]);
 
   return (
     <FormattedMessage id="ui-data-export.mappingProfiles.newProfile">
@@ -124,7 +126,8 @@ const JobProfileDetails = props => {
 };
 
 JobProfileDetails.propTypes = {
-  isProfileAlreadyInUse: PropTypes.bool.isRequired,
+  isProfileUsed: PropTypes.bool.isRequired,
+  isDefaultProfile: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   mappingProfile: PropTypes.object,
   jobProfile: PropTypes.object,

--- a/src/settings/JobProfiles/JobProfileDetailsActionMenu/JobProfileDetailsActionMenu.js
+++ b/src/settings/JobProfiles/JobProfileDetailsActionMenu/JobProfileDetailsActionMenu.js
@@ -9,14 +9,15 @@ import {
 
 const JobProfileDetailsActionMenu = ({
   onToggle,
-  isProfileAlreadyInUse,
+  isProfileUsed,
+  isDefaultProfile,
 }) => {
   return (
     <>
       <Button
         data-test-edit-profile-button
         buttonStyle="dropdownItem"
-        disabled={isProfileAlreadyInUse}
+        disabled={isDefaultProfile || isProfileUsed}
         onClick={onToggle}
       >
         <Icon icon="edit">
@@ -35,7 +36,7 @@ const JobProfileDetailsActionMenu = ({
       <Button
         data-test-delete-profile-button
         buttonStyle="dropdownItem"
-        disabled={isProfileAlreadyInUse}
+        disabled={isDefaultProfile || isProfileUsed}
         onClick={onToggle}
       >
         <Icon icon="trash">
@@ -47,7 +48,8 @@ const JobProfileDetailsActionMenu = ({
 };
 
 JobProfileDetailsActionMenu.propTypes = {
-  isProfileAlreadyInUse: PropTypes.bool.isRequired,
+  isProfileUsed: PropTypes.bool.isRequired,
+  isDefaultProfile: PropTypes.bool.isRequired,
   onToggle: PropTypes.func.isRequired,
 };
 

--- a/src/settings/JobProfiles/JobProfileDetailsActionMenu/JobProfileDetailsActionMenu.js
+++ b/src/settings/JobProfiles/JobProfileDetailsActionMenu/JobProfileDetailsActionMenu.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Icon,
+} from '@folio/stripes/components';
+
+const JobProfileDetailsActionMenu = ({
+  onToggle,
+  isProfileAlreadyInUse,
+}) => {
+  return (
+    <>
+      <Button
+        data-test-edit-profile-button
+        buttonStyle="dropdownItem"
+        disabled={isProfileAlreadyInUse}
+        onClick={onToggle}
+      >
+        <Icon icon="edit">
+          <FormattedMessage id="stripes-data-transfer-components.edit" />
+        </Icon>
+      </Button>
+      <Button
+        data-test-duplicate-profile-button
+        buttonStyle="dropdownItem"
+        onClick={onToggle}
+      >
+        <Icon icon="duplicate">
+          <FormattedMessage id="stripes-data-transfer-components.duplicate" />
+        </Icon>
+      </Button>
+      <Button
+        data-test-delete-profile-button
+        buttonStyle="dropdownItem"
+        disabled={isProfileAlreadyInUse}
+        onClick={onToggle}
+      >
+        <Icon icon="trash">
+          <FormattedMessage id="stripes-data-transfer-components.delete" />
+        </Icon>
+      </Button>
+    </>
+  );
+};
+
+JobProfileDetailsActionMenu.propTypes = {
+  isProfileAlreadyInUse: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+};
+
+export default JobProfileDetailsActionMenu;

--- a/src/settings/JobProfiles/JobProfileDetailsActionMenu/index.js
+++ b/src/settings/JobProfiles/JobProfileDetailsActionMenu/index.js
@@ -1,0 +1,1 @@
+export { default as JobProfileDetailsActionMenu } from './JobProfileDetailsActionMenu';

--- a/src/settings/JobProfiles/JobProfileDetailsRoute/JobProfileDetailsRoute.js
+++ b/src/settings/JobProfiles/JobProfileDetailsRoute/JobProfileDetailsRoute.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   get,
@@ -6,27 +6,35 @@ import {
 } from 'lodash';
 
 import { JobProfileDetails } from '../JobProfileDetails';
+import { DEFAULT_JOB_PROFILE_ID } from '../../../utils';
 
 const JobProfileDetailsRoute = ({
   resources: {
     jobProfile,
     mappingProfile,
+    jobExecutions,
   },
   history,
   location,
   match,
 }) => {
-  // `find` is used to make sure the matched job profile and mapping profile are displayed to avoid
+  // `find` is used to make sure the matched job profile, mapping profile and job executions are displayed to avoid
   // the flickering because of the disappearing of the previous and appearing of the new ones
   const jobProfileRecord = find([get(jobProfile, 'records.0', {})], { id: match.params.id });
   const mappingProfileRecord = find([get(mappingProfile, 'records.0', {})], { id: jobProfileRecord?.mappingProfileId });
+  const isDefaultProfile = jobProfileRecord?.id === DEFAULT_JOB_PROFILE_ID;
+  const isProfileAlreadyInUse = isDefaultProfile || Boolean(find([get(jobExecutions, 'records.0', {})], { jobProfileId: match.params.id }));
+  const handleCancel = useCallback(() => {
+    history.push(`/settings/data-export/job-profiles${location.search}`);
+  }, [location.search]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <JobProfileDetails
       jobProfile={jobProfileRecord}
       mappingProfile={mappingProfileRecord}
-      isLoading={!jobProfileRecord || !mappingProfileRecord}
-      onCancel={() => history.push(`/settings/data-export/job-profiles${location.search}`)}
+      isProfileAlreadyInUse={isProfileAlreadyInUse}
+      isLoading={!jobProfileRecord || !mappingProfileRecord || (!isDefaultProfile && !jobExecutions.hasLoaded)}
+      onCancel={handleCancel}
     />
   );
 };
@@ -37,6 +45,7 @@ JobProfileDetailsRoute.propTypes = {
   match: PropTypes.shape({ params: PropTypes.shape({ id: PropTypes.string }) }).isRequired,
   resources: PropTypes.shape({
     jobProfile: PropTypes.shape({}),
+    jobExecutions: PropTypes.shape({ hasLoaded: PropTypes.bool }),
     mappingProfile: PropTypes.shape({}),
   }).isRequired,
 };
@@ -53,6 +62,15 @@ JobProfileDetailsRoute.manifest = Object.freeze({
       const mappingProfileId = get(props.resources, 'jobProfile.records.0.mappingProfileId');
 
       return mappingProfileId ? `data-export/mappingProfiles/${mappingProfileId}` : null;
+    },
+  },
+  jobExecutions: {
+    type: 'okapi',
+    records: 'jobExecutions',
+    path: (queryParams, pathComponents) => {
+      const { id } = pathComponents;
+
+      return id !== DEFAULT_JOB_PROFILE_ID ? `data-export/jobExecutions?query=jobProfileId==${id}&limit=1` : null;
     },
   },
 });

--- a/src/settings/JobProfiles/JobProfileDetailsRoute/JobProfileDetailsRoute.js
+++ b/src/settings/JobProfiles/JobProfileDetailsRoute/JobProfileDetailsRoute.js
@@ -20,10 +20,12 @@ const JobProfileDetailsRoute = ({
 }) => {
   // `find` is used to make sure the matched job profile, mapping profile and job executions are displayed to avoid
   // the flickering because of the disappearing of the previous and appearing of the new ones
+  // TODO: try `useManifest` hook once it is ready to avoid that
   const jobProfileRecord = find([get(jobProfile, 'records.0', {})], { id: match.params.id });
   const mappingProfileRecord = find([get(mappingProfile, 'records.0', {})], { id: jobProfileRecord?.mappingProfileId });
+  const isProfileUsed = Boolean(find([get(jobExecutions, 'records.0', {})], { jobProfileId: match.params.id }));
+
   const isDefaultProfile = jobProfileRecord?.id === DEFAULT_JOB_PROFILE_ID;
-  const isProfileAlreadyInUse = isDefaultProfile || Boolean(find([get(jobExecutions, 'records.0', {})], { jobProfileId: match.params.id }));
   const handleCancel = useCallback(() => {
     history.push(`/settings/data-export/job-profiles${location.search}`);
   }, [location.search]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -32,7 +34,8 @@ const JobProfileDetailsRoute = ({
     <JobProfileDetails
       jobProfile={jobProfileRecord}
       mappingProfile={mappingProfileRecord}
-      isProfileAlreadyInUse={isProfileAlreadyInUse}
+      isProfileUsed={isProfileUsed}
+      isDefaultProfile={isDefaultProfile}
       isLoading={!jobProfileRecord || !mappingProfileRecord || (!isDefaultProfile && !jobExecutions.hasLoaded)}
       onCancel={handleCancel}
     />

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
@@ -19,6 +19,7 @@ import {
   MultiColumnList,
   NoValue,
   Row,
+  Button,
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
@@ -71,6 +72,7 @@ const MappingProfileDetails = props => {
           <FullScreenView
             id="mapping-profile-details"
             paneTitle={record.name}
+            actionMenu={<Button buttonStyle="dropdownItem fullWidth" />}
             onCancel={onCancel}
           >
             {!hasLoaded

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,3 +12,5 @@ export const QUERY_TEMPLATE = '(sortby "%{query.query}")';
 export const INITIAL_RESULT_COUNT = 100;
 
 export const RESULT_COUNT_INCREMENT = 100;
+
+export const DEFAULT_JOB_PROFILE_ID = '6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,4 +13,5 @@ export const INITIAL_RESULT_COUNT = 100;
 
 export const RESULT_COUNT_INCREMENT = 100;
 
+// TODO: for now constant below is the only way to check whether the given profile is default one: once alternative solution is in place they should be removed (UIDEXP-128)
 export const DEFAULT_JOB_PROFILE_ID = '6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a';

--- a/test/bigtest/network/scenarios/fetch-job-profiles-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-profiles-success.js
@@ -1,5 +1,7 @@
+import { DEFAULT_JOB_PROFILE_ID } from '../../../../src/utils';
+
 export const jobProfile = {
-  id: 'b38e006e-99dd-11ea-bb37-0242ac130008',
+  id: DEFAULT_JOB_PROFILE_ID,
   name: 'A Lorem impsum 1',
   destination: 'fileSystem',
   description: 'Job profile description',

--- a/test/bigtest/tests/job-profiles/jobProfileDetails-test.js
+++ b/test/bigtest/tests/job-profiles/jobProfileDetails-test.js
@@ -32,7 +32,7 @@ describe('Job profile details: default job profile', () => {
       await jobProfileDetails.fullScreen.closeButton.click();
     });
 
-    it('should navigate to mapping profiles settings page', function () {
+    it('should navigate to job profiles settings page', function () {
       expect(this.location.pathname.endsWith('/data-export/job-profiles')).to.be.true;
     });
   });

--- a/test/bigtest/tests/job-profiles/jobProfileDetails-test.js
+++ b/test/bigtest/tests/job-profiles/jobProfileDetails-test.js
@@ -12,15 +12,13 @@ import { mappingProfile } from '../../network/scenarios/fetch-mapping-profiles-s
 
 const jobProfileDetails = new JobProfileDetailsInteractor();
 
-describe('Job profile details', () => {
+describe('Job profile details: default job profile', () => {
   setupApplication();
 
   beforeEach(function () {
     const jobProfileRecord = this.server.create('job-profile', jobProfile);
 
-    this.server.create('mapping-profile', mappingProfile);
-
-    this.server.get('/data-export/mappingProfiles/:id', schema => schema.mappingProfiles.find(jobProfileRecord.mappingProfileId).attrs);
+    this.server.get('/data-export/mappingProfiles/:id', mappingProfile);
 
     this.visit(`/settings/data-export/job-profiles/view/${jobProfileRecord.id}`);
   });

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
@@ -46,7 +46,8 @@ describe('JobProfileDetails', () => {
               stripes={stripes}
               jobProfile={jobProfile}
               mappingProfile={mappingProfile}
-              isProfileAlreadyInUse
+              isDefaultProfile
+              isProfileUsed
               onCancel={noop}
             />
           </Router>
@@ -119,7 +120,8 @@ describe('JobProfileDetails', () => {
                 description: null,
               }}
               mappingProfile={mappingProfile}
-              isProfileAlreadyInUse={false}
+              isDefaultProfile={false}
+              isProfileUsed={false}
               onCancel={noop}
             />
           </Router>
@@ -153,7 +155,8 @@ describe('JobProfileDetails', () => {
             <JobProfileDetails
               stripes={stripes}
               isLoading
-              isProfileAlreadyInUse
+              isDefaultProfile={false}
+              isProfileUsed
               onCancel={noop}
             />
           </Router>

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
@@ -37,7 +37,7 @@ describe('JobProfileDetails', () => {
     await cleanup();
   });
 
-  describe('rendering job profile details', () => {
+  describe('rendering details for a job profile which is already in use', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Paneset>
@@ -46,6 +46,7 @@ describe('JobProfileDetails', () => {
               stripes={stripes}
               jobProfile={jobProfile}
               mappingProfile={mappingProfile}
+              isProfileAlreadyInUse
               onCancel={noop}
             />
           </Router>
@@ -92,9 +93,21 @@ describe('JobProfileDetails', () => {
       expect(jobProfileDetails.summary.protocol.value.text).to.equal('-');
       expect(jobProfileDetails.summary.mappingProfile.value.text).to.equal(mappingProfile.name);
     });
+
+    describe('clicking on action menu button', () => {
+      beforeEach(async () => {
+        await jobProfileDetails.fullScreen.actionMenu.click();
+      });
+
+      it('should display action buttons in the proper state', () => {
+        expect(jobProfileDetails.editProfileButton.$root.disabled).to.be.true;
+        expect(jobProfileDetails.duplicateProfileButton.$root.disabled).to.be.false;
+        expect(jobProfileDetails.deleteProfileButton.$root.disabled).to.be.true;
+      });
+    });
   });
 
-  describe('rendering job profile details', () => {
+  describe('rendering details without description for a job profile which is not already in use', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Paneset>
@@ -106,6 +119,7 @@ describe('JobProfileDetails', () => {
                 description: null,
               }}
               mappingProfile={mappingProfile}
+              isProfileAlreadyInUse={false}
               onCancel={noop}
             />
           </Router>
@@ -117,9 +131,21 @@ describe('JobProfileDetails', () => {
     it('should display no value in description', () => {
       expect(jobProfileDetails.summary.description.value.text).to.equal('-');
     });
+
+    describe('clicking on action menu button', () => {
+      beforeEach(async () => {
+        await jobProfileDetails.fullScreen.actionMenu.click();
+      });
+
+      it('should display action buttons enabled', () => {
+        expect(jobProfileDetails.editProfileButton.$root.disabled).to.be.false;
+        expect(jobProfileDetails.duplicateProfileButton.$root.disabled).to.be.false;
+        expect(jobProfileDetails.deleteProfileButton.$root.disabled).to.be.false;
+      });
+    });
   });
 
-  describe('rendering job profile details', () => {
+  describe('rendering job profile details in loading state', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Paneset>
@@ -127,6 +153,7 @@ describe('JobProfileDetails', () => {
             <JobProfileDetails
               stripes={stripes}
               isLoading
+              isProfileAlreadyInUse
               onCancel={noop}
             />
           </Router>

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { cleanup } from '@bigtest/react';
+import {
+  describe,
+  beforeEach,
+  it,
+  before,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Paneset } from '@folio/stripes/components';
+import { mountWithContext } from '@folio/stripes-data-transfer-components/interactors';
+
+import { translationsProperties } from '../../../../helpers/translationsProperties';
+import { JobProfileDetailsRoute } from '../../../../../../src/settings/JobProfiles/JobProfileDetailsRoute';
+import { JobProfileDetailsInteractor } from './interactors/JobProfileDetailsInteractor';
+import { mappingProfile } from '../../../../network/scenarios/fetch-mapping-profiles-success';
+import { jobProfile } from '../../../../network/scenarios/fetch-job-profiles-success';
+import { DEFAULT_JOB_PROFILE_ID } from '../../../../../../src/utils';
+
+async function setupJobProfileDetailsRoute({
+  resources,
+  matchParams = {},
+  history = {},
+} = {}) {
+  await mountWithContext(
+    <Paneset>
+      <Router>
+        <JobProfileDetailsRoute
+          resources={resources}
+          history={history}
+          location={{}}
+          match={{ params: matchParams }}
+        />
+      </Router>
+    </Paneset>,
+    translationsProperties,
+  );
+}
+
+describe('JobProfileDetails', () => {
+  const jobProfileDetails = new JobProfileDetailsInteractor();
+
+  before(async () => {
+    await cleanup();
+  });
+
+  describe('rendering details for a job profile without job profile data', () => {
+    beforeEach(async () => {
+      await setupJobProfileDetailsRoute({
+        resources: {
+          jobProfile: { records: [] },
+          mappingProfile: { records: [] },
+          jobExecutions: { records: [] },
+        },
+      });
+    });
+
+    it('should display preloader', () => {
+      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+    });
+  });
+
+  describe('rendering details for a job profile without mapping profile data', () => {
+    beforeEach(async () => {
+      await setupJobProfileDetailsRoute({
+        resources: {
+          jobProfile: { records: [jobProfile] },
+          mappingProfile: { records: [] },
+          jobExecutions: { records: [] },
+        },
+        matchParams: { id: DEFAULT_JOB_PROFILE_ID },
+      });
+    });
+
+    it('should display preloader', () => {
+      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+    });
+  });
+
+  describe('rendering details for non default job profile without job execution data', () => {
+    beforeEach(async () => {
+      const nonDefaultJobProfileId = 'job-profile-id';
+
+      await setupJobProfileDetailsRoute({
+        resources: {
+          jobProfile: {
+            records: [{
+              ...jobProfile,
+              id: nonDefaultJobProfileId,
+            }],
+          },
+          mappingProfile: { records: [mappingProfile] },
+          jobExecutions: { records: [] },
+        },
+        matchParams: { id: nonDefaultJobProfileId },
+      });
+    });
+
+    it('should display preloader', () => {
+      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+    });
+  });
+});

--- a/test/bigtest/tests/units/settings/JopProfileDetails/interactors/JobProfileDetailsInteractor.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/interactors/JobProfileDetailsInteractor.js
@@ -2,6 +2,7 @@ import { interactor } from '@bigtest/interactor';
 
 import { AccordionSetInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
 import MetaSectionInteractor from '@folio/stripes-components/lib/MetaSection/tests/interactor';
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 import {
   FullScreenViewInteractor,
   PreloaderInteractor,
@@ -18,4 +19,7 @@ export class JobProfileDetailsInteractor {
   summary = new SummaryContentInteractor();
   preloader = new PreloaderInteractor();
   metadata = new MetaSectionInteractor();
+  editProfileButton = new ButtonInteractor('[data-test-edit-profile-button]');
+  duplicateProfileButton = new ButtonInteractor('[data-test-duplicate-profile-button]');
+  deleteProfileButton = new ButtonInteractor('[data-test-delete-profile-button]');
 }

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/interactors/TransformationsInteractor.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/interactors/TransformationsInteractor.js
@@ -1,13 +1,8 @@
-import {
-  interactor,
-  scoped,
-} from '@bigtest/interactor';
+import { interactor } from '@bigtest/interactor';
 
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
-import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 
 @interactor
 export class TransformationsInteractor {
   list = new MultiColumnListInteractor('#mapping-profile-details-transformations');
-  addButton = scoped('[data-test-add-button]', ButtonInteractor);
 }


### PR DESCRIPTION
## Purpose

Implement a job profile actions menu in the scope of the [UIDEXP-84](https://issues.folio.org/browse/UIDEXP-84).

## Screenshots

### Default job profile
<img width="1220" alt="Screen Shot 2020-07-03 at 17 36 31" src="https://user-images.githubusercontent.com/40821852/86478965-ea5b2b00-bd53-11ea-8070-6322485c3733.png">

### Profile which is not in use yet
<img width="1220" alt="Screen Shot 2020-07-03 at 17 36 44" src="https://user-images.githubusercontent.com/40821852/86478960-e8916780-bd53-11ea-8f80-3cd136cc62e7.png">