### PR TITLE
UIDEXP-117: Fix accessibility string building for MCL components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add job name display in job logs and executions. UIDEXP-116.
 * Implement job profile details page. UIDEXP-86.
 * Implement job profile details action menu. UIDEXP-84.
+* Fix accessibility string building for MCL components. UIDEXP-117.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/components/ChooseJobProfile/ChooseJobProfile.js
+++ b/src/components/ChooseJobProfile/ChooseJobProfile.js
@@ -11,25 +11,23 @@ import { ConfirmationModal } from '@folio/stripes/components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   JobProfiles,
-  getJobProfilesColumnProperties,
+  useJobProfilesProperties,
   DEFAULT_JOB_PROFILES_COLUMNS,
-  getJobProfilesItemFormatter,
+  useListFormatter,
 } from '@folio/stripes-data-transfer-components';
 
 import { jobProfilesManifest } from '../../common';
 
-const customProperties = getJobProfilesColumnProperties({
+const customProperties = {
   columnWidths: { description: '40%' },
-  columnMapping: { description: <FormattedMessage id="ui-data-export.description" /> },
+  columnMapping: { description: 'ui-data-export.description' },
   visibleColumns: [
     DEFAULT_JOB_PROFILES_COLUMNS.NAME,
     'description',
     DEFAULT_JOB_PROFILES_COLUMNS.UPDATED,
     DEFAULT_JOB_PROFILES_COLUMNS.UPDATED_BY,
   ],
-});
-
-const formatter = getJobProfilesItemFormatter({});
+};
 
 const ChooseJobProfileComponent = ({
   resources,
@@ -50,7 +48,7 @@ const ChooseJobProfileComponent = ({
       <JobProfiles
         parentResources={resources}
         parentMutator={mutator}
-        formatter={formatter}
+        formatter={useListFormatter({ description: record => record.description || '' })}
         hasSearchForm={false}
         lastMenu={<div />}
         titleId="ui-data-export.jobProfiles.selectProfile.title"
@@ -61,7 +59,7 @@ const ChooseJobProfileComponent = ({
             setSelectedProfile(profile);
           },
         }}
-        {...customProperties}
+        {...useJobProfilesProperties(customProperties)}
       />
       <ConfirmationModal
         id="choose-job-profile-confirmation-modal"

--- a/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
+++ b/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import {
   match as matchShape,
   history as historyShape,
@@ -10,27 +9,25 @@ import {
 import { Route } from '@folio/stripes/core';
 import {
   JobProfiles,
-  getJobProfilesColumnProperties,
+  useJobProfilesProperties,
   DEFAULT_JOB_PROFILES_COLUMNS,
-  getJobProfilesItemFormatter,
+  useListFormatter,
 } from '@folio/stripes-data-transfer-components';
 
 import { NewJobProfileRoute } from '../NewJobProfileRoute';
 import { JobProfileDetailsRoute } from '../JobProfileDetailsRoute';
 import { jobProfilesManifest } from '../../../common';
 
-const customProperties = getJobProfilesColumnProperties({
+const customProperties = {
   columnWidths: { protocol: '70px' },
-  columnMapping: { protocol: <FormattedMessage id="ui-data-export.protocol" /> },
+  columnMapping: { protocol: 'ui-data-export.protocol' },
   visibleColumns: [
     DEFAULT_JOB_PROFILES_COLUMNS.NAME,
     'protocol',
     DEFAULT_JOB_PROFILES_COLUMNS.UPDATED,
     DEFAULT_JOB_PROFILES_COLUMNS.UPDATED_BY,
   ],
-});
-
-const formatter = getJobProfilesItemFormatter({ protocol: () => '' });
+};
 
 const JobProfilesContainer = ({
   history,
@@ -47,8 +44,8 @@ const JobProfilesContainer = ({
       <JobProfiles
         parentResources={resources}
         parentMutator={mutator}
-        formatter={formatter}
-        {...customProperties}
+        formatter={useListFormatter({ protocol: () => '' })}
+        {...useJobProfilesProperties(customProperties)}
       />
       <Route
         path={`${match.path}/view/:id`}

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import {
   match as matchShape,
   history as historyShape,
@@ -11,9 +10,9 @@ import { Route } from '@folio/stripes/core';
 import { makeQueryFunction } from '@folio/stripes/smart-components';
 import {
   MappingProfiles,
-  getMappingProfilesColumnProperties,
+  useMappingProfilesProperties,
   DEFAULT_MAPPING_PROFILES_COLUMNS,
-  getMappingProfilesItemFormatter,
+  useMappingProfileListFormatter,
 } from '@folio/stripes-data-transfer-components';
 
 import {
@@ -26,9 +25,9 @@ import { generateTransformationFieldsValues } from '../MappingProfilesForm/Trans
 import { mappingProfileTransformations } from '../MappingProfilesForm/TransformationsField/transformations';
 import { MappingProfileDetailsRoute } from '../MappingProfileDetailsRoute';
 
-const customProperties = getMappingProfilesColumnProperties({
+const customProperties = {
   columnWidths: { format: '70px' },
-  columnMapping: { format: <FormattedMessage id="ui-data-export.format" /> },
+  columnMapping: { format: 'ui-data-export.format' },
   visibleColumns: [
     DEFAULT_MAPPING_PROFILES_COLUMNS.NAME,
     DEFAULT_MAPPING_PROFILES_COLUMNS.FOLIO_RECORD,
@@ -36,7 +35,7 @@ const customProperties = getMappingProfilesColumnProperties({
     DEFAULT_MAPPING_PROFILES_COLUMNS.UPDATED,
     DEFAULT_MAPPING_PROFILES_COLUMNS.UPDATED_BY,
   ],
-});
+};
 
 const queryTemplate = '(sortby "%{query.query}")';
 const sortMap = {
@@ -65,8 +64,8 @@ const MappingProfilesContainer = ({
       <MappingProfiles
         parentResources={resources}
         parentMutator={mutator}
-        formatter={getMappingProfilesItemFormatter({ format: ({ outputFormat }) => outputFormat })}
-        {...customProperties}
+        formatter={useMappingProfileListFormatter({ format: ({ outputFormat }) => outputFormat })}
+        {...useMappingProfilesProperties(customProperties)}
       />
       <Route
         path={`${match.path}/view/:id`}


### PR DESCRIPTION
## Purposes

Fix accessibility string building for used MCL based pages: MappingProfiles, JobProfiles, JobLogs. [Bug](https://issues.folio.org/browse/UIDEXP-117).

## Screenshots

![Screen Shot 2020-07-07 at 1 35 50 PM](https://user-images.githubusercontent.com/50317804/86908333-0af1ff00-c11f-11ea-8d85-96e9df0fe012.png)

![Screen Shot 2020-07-07 at 1 36 01 PM](https://user-images.githubusercontent.com/50317804/86908340-0d545900-c11f-11ea-9c37-c75194a210e1.png)

![Screen Shot 2020-07-07 at 1 36 34 PM](https://user-images.githubusercontent.com/50317804/86908344-0decef80-c11f-11ea-9993-273561989032.png)

![Screen Shot 2020-07-07 at 1 53 23 PM](https://user-images.githubusercontent.com/50317804/86908345-0decef80-c11f-11ea-805e-05d6600c9b39.png)
