### PR TITLE
UIDEXP-129: Fix spacing display of Transformation fields on mapping profile view page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Implement job profile details action menu. UIDEXP-84.
 * Fix accessibility string building for MCL components. UIDEXP-117.
 * Implement mapping profile details action menu. UIDEXP-75.
+* Fix spacing display of Transformation fields on mapping profile view page. UIDEXP-129.
 
 ## [2.0.0](https://github.com/folio-org/ui-data-export/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v1.0.2...v2.0.0)

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.css
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.css
@@ -1,3 +1,10 @@
 .recordTypesList {
   background-color: transparent !important;
 }
+
+.transformation {
+  font-size: inherit;
+  font-family: inherit;
+  letter-spacing: inherit;
+  margin: 0;
+}

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
@@ -39,7 +39,14 @@ const columnWidths = {
 const visibleColumns = ['fieldName', 'transformation'];
 const formatter = {
   fieldName: record => mappingProfileTransformations.find(({ path }) => path === record.path).displayName,
-  transformation: record => record.transformation,
+  transformation: record => (
+    <pre
+      title={record.transformation}
+      className={css.transformation}
+    >
+      {record.transformation}
+    </pre>
+  ),
 };
 
 const MappingProfileDetails = props => {

--- a/test/bigtest/network/scenarios/fetch-mapping-profiles-success.js
+++ b/test/bigtest/network/scenarios/fetch-mapping-profiles-success.js
@@ -5,13 +5,22 @@ export const mappingProfileWithTransformations = {
   name: 'AP Holdings 1',
   description: 'AP Holdings 1 description',
   recordTypes: ['HOLDINGS'],
-  transformations: [{
-    fieldId: 'callNumber',
-    path: '$.holdings[*].callNumber',
-    enabled: true,
-    transformation: 'test',
-    recordType: 'HOLDINGS',
-  }],
+  transformations: [
+    {
+      fieldId: 'callNumber',
+      path: '$.holdings[*].callNumber',
+      enabled: true,
+      transformation: '$900  1',
+      recordType: 'HOLDINGS',
+    },
+    {
+      fieldId: 'callNumberPrefix',
+      path: '$.holdings[*].callNumberPrefix',
+      enabled: true,
+      transformation: '$901 2',
+      recordType: 'HOLDINGS',
+    },
+  ],
   userInfo: {
     firstName: 'Donald',
     lastName: 'S',

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
@@ -114,7 +114,9 @@ describe('MappingProfileDetails', () => {
 
     it('should display correct transformations values', () => {
       expect(mappingProfileDetails.transformations.list.rows(0).cells(0).text).to.equal('Holdings - Call number');
-      expect(mappingProfileDetails.transformations.list.rows(0).cells(1).text).to.equal('test');
+      expect(mappingProfileDetails.transformations.list.rows(0).cells(1).$root.textContent).to.equal('$900  1');
+      expect(mappingProfileDetails.transformations.list.rows(1).cells(0).text).to.equal('Holdings - Call number - prefix');
+      expect(mappingProfileDetails.transformations.list.rows(1).cells(1).text).to.equal('$901 2');
     });
 
     describe('clicking on action menu button', () => {


### PR DESCRIPTION
## Purposes

I wrapped transformations value by `<pre>` tag to support several spacing on mapping profile details page. [Bug](https://issues.folio.org/browse/UIDEXP-129).

## Screenshots

![Screenshot 2020-07-09 at 12 55 57](https://user-images.githubusercontent.com/50317804/87025844-946b0500-c1e3-11ea-9f0a-7719c6529abe.png)


