### PR TITLE
UIDEXP-69: Implement record type filter behavior in add mapping profile transformations modal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,7 @@
     "object-property-newline": [
       "error",
       {
-        "allowMultiplePropertiesPerLine": false
+        "allowAllPropertiesOnSameLine": false
       }
     ],
     "no-multiple-empty-lines": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Refactor to miragejs from bigtest/mirage. UIDEXP-137.
 * Implement add mapping profile transformations modal. UIDEXP-104.
 * Add mapping profiles deleting. UIDEXP-133.
+* Implement record type filter behavior in add mapping profile transformations modal. UIDEXP-69.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
+++ b/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   match as matchShape,
@@ -37,7 +37,10 @@ const JobProfilesContainer = ({
   mutator,
   stripes,
 }) => {
-  const JobProfileDetailsRouteConnected = React.useMemo(() => stripes.connect(JobProfileDetailsRoute, { dataKey: 'job-profile-details' }), []); // eslint-disable-line react-hooks/exhaustive-deps
+  const JobProfileDetailsRouteConnected = useMemo(
+    () => stripes.connect(JobProfileDetailsRoute, { dataKey: 'job-profile-details' }),
+    [stripes],
+  );
 
   return (
     <>

--- a/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
@@ -1,33 +1,21 @@
-import React, { useState } from 'react';
+import React, {
+  memo,
+  useState,
+  useCallback,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
-import { isEqual } from 'lodash';
 import { Field } from 'react-final-form';
 
-import {
-  Label,
-  Checkbox,
-} from '@folio/stripes/components';
-import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
+import { Label } from '@folio/stripes/components';
+
+import { RecordTypeField } from '../../RecordTypeField';
 
 import css from './FolioRecordTypeField.css';
 
-const folioRecordTypes = [
-  {
-    value: FOLIO_RECORD_TYPES.INSTANCE.type,
-    label: <FormattedMessage id={FOLIO_RECORD_TYPES.INSTANCE.captionId} />,
-  },
-  {
-    value: FOLIO_RECORD_TYPES.HOLDINGS.type,
-    label: <FormattedMessage id={FOLIO_RECORD_TYPES.HOLDINGS.captionId} />,
-  },
-  {
-    value: FOLIO_RECORD_TYPES.ITEM.type,
-    label: <FormattedMessage id={FOLIO_RECORD_TYPES.ITEM.captionId} />,
-  },
-];
-
-export const FolioRecordTypeField = () => {
+export const FolioRecordTypeField = memo(() => {
   const [touched, setTouched] = useState(false);
+
+  const handleRecordTypeChange = useCallback(() => setTouched(true), []);
 
   return (
     <div
@@ -41,34 +29,11 @@ export const FolioRecordTypeField = () => {
       >
         <FormattedMessage id="stripes-data-transfer-components.folioRecordType" />
       </Label>
-      <div
+      <RecordTypeField
         id="folio-record-type"
-        data-test-checkboxes-container
-      >
-        {folioRecordTypes.map(option => (
-          <div key={option.value}>
-            <Field
-              name="recordTypes"
-              id={`folio-record-type-${option.value}`}
-              type="checkbox"
-              value={option.value}
-              isEqual={isEqual}
-              render={fieldProps => {
-                return (
-                  <Checkbox
-                    {...fieldProps.input}
-                    label={option.label}
-                    onChange={event => {
-                      setTouched(true);
-                      fieldProps.input.onChange(event);
-                    }}
-                  />
-                );
-              }}
-            />
-          </div>
-        ))}
-      </div>
+        name="recordTypes"
+        onChange={handleRecordTypeChange}
+      />
       <div
         role="alert"
         data-test-folio-record-type-error
@@ -82,4 +47,4 @@ export const FolioRecordTypeField = () => {
       </div>
     </div>
   );
-};
+});

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.css
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.css
@@ -4,10 +4,6 @@
   padding: 0;
 }
 
-.searchGroupWrap {
-  margin-bottom: 0.5rem;
-}
-
 .modalFooter {
   display: flex;
   justify-content: space-between;

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -1,32 +1,34 @@
 import React, {
   useState,
+  useCallback,
   useEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { noop } from 'lodash';
+import {
+  get,
+  noop,
+} from 'lodash';
 
 import {
   Button,
-  Icon,
   Modal,
   Pane,
   Paneset,
-  SearchField,
-  AccordionSet,
-  Accordion,
-  FilterAccordionHeader,
-  Checkbox,
 } from '@folio/stripes/components';
 import {
   ExpandFilterPaneButton,
   CollapseFilterPaneButton,
 } from '@folio/stripes/smart-components';
 
+import { recordTypes } from '../RecordTypeField';
 import { TransformationsForm } from './TransformationsForm';
-import { mappingProfileTransformations } from './TransformationsField/transformations';
+import { SearchForm } from './SearchForm';
 
 import css from './MappingProfilesTransformationsModal.css';
+
+const initialSearchFormValues = { filters: { recordTypes: recordTypes.map(recordType => recordType.value) } };
+const fullWidthStyle = { style: { width: '100%' } };
 
 export const MappingProfilesTransformationsModal = ({
   isOpen,
@@ -34,19 +36,26 @@ export const MappingProfilesTransformationsModal = ({
   onCancel,
 }) => {
   const [isFilterPaneOpen, setFilterPaneOpen] = useState(true);
+  const [searchFilters, setSearchFilters] = useState(initialSearchFormValues.filters);
 
   const totalSelectedCount = 0;
-  const searchResultsCount = mappingProfileTransformations.length;
 
   useEffect(() => {
     if (!isOpen) {
       setFilterPaneOpen(true);
+      setSearchFilters(initialSearchFormValues.filters);
     }
   }, [isOpen]);
 
-  const toggleFilterPane = () => {
-    setFilterPaneOpen(curState => !curState);
-  };
+  const searchResults = initialTransformationsValues.transformations
+    .filter(value => get(searchFilters, 'recordTypes', []).includes(value.recordType));
+
+  const toggleFilterPane = useCallback(() => setFilterPaneOpen(curState => !curState), []);
+
+  const handleFiltersChange = useCallback((key, value) => setSearchFilters(curFilters => ({
+    ...curFilters,
+    [key]: value,
+  })), []);
 
   const renderFooter = () => {
     return (
@@ -89,63 +98,19 @@ export const MappingProfilesTransformationsModal = ({
       onClose={onCancel}
     >
       <Paneset>
-        {isFilterPaneOpen && (
-          <Pane
-            data-test-transformations-search-pane
-            defaultWidth="30%"
-            paneTitle={<FormattedMessage id="ui-data-export.searchAndFilter" />}
-            lastMenu={<CollapseFilterPaneButton onClick={toggleFilterPane} />}
-          >
-            <form>
-              <div className={css.searchGroupWrap}>
-                <FormattedMessage id="ui-data-export.mappingProfiles.transformations.searchFields">
-                  {label => (
-                    <SearchField
-                      data-test-transformations-search-field
-                      aria-label={label}
-                      autoFocus
-                      marginBottom0
-                    />
-                  )}
-                </FormattedMessage>
-              </div>
-              <div>
-                <Button
-                  data-test-transformations-reset
-                  buttonStyle="none"
-                >
-                  <Icon icon="times-circle-solid">
-                    <FormattedMessage id="ui-data-export.resetAll" />
-                  </Icon>
-                </Button>
-              </div>
-              <AccordionSet id="transformations-filter-accordions">
-                <Accordion
-                  id="transformations-record-type-accordion"
-                  header={FilterAccordionHeader}
-                  label={<FormattedMessage id="ui-data-export.recordType" />}
-                  separator={false}
-                >
-                  <Checkbox
-                    label={<FormattedMessage id="stripes-data-transfer-components.recordTypes.instance" />}
-                    fullWidth
-                    checked
-                  />
-                  <Checkbox
-                    label={<FormattedMessage id="stripes-data-transfer-components.recordTypes.holdings" />}
-                    fullWidth
-                    checked
-                  />
-                  <Checkbox
-                    label={<FormattedMessage id="stripes-data-transfer-components.recordTypes.item" />}
-                    fullWidth
-                    checked
-                  />
-                </Accordion>
-              </AccordionSet>
-            </form>
-          </Pane>
-        )}
+        <Pane
+          data-test-transformations-search-pane
+          defaultWidth="30%"
+          paneTitle={<FormattedMessage id="ui-data-export.searchAndFilter" />}
+          lastMenu={<CollapseFilterPaneButton onClick={toggleFilterPane} />}
+          hidden={!isFilterPaneOpen}
+        >
+          <SearchForm
+            initialValues={initialSearchFormValues}
+            onFiltersChange={handleFiltersChange}
+            onSubmit={noop}
+          />
+        </Pane>
         <Pane
           data-test-transformations-results-pane
           defaultWidth="fill"
@@ -154,13 +119,15 @@ export const MappingProfilesTransformationsModal = ({
           paneSub={(
             <FormattedMessage
               id="ui-data-export.mappingProfiles.transformations.searchResultsCountHeader"
-              values={{ count: searchResultsCount }}
+              values={{ count: searchResults.length }}
             />
           )}
           firstMenu={!isFilterPaneOpen ? <ExpandFilterPaneButton onClick={toggleFilterPane} /> : null}
+          {...(!isFilterPaneOpen && fullWidthStyle)}
         >
           <TransformationsForm
             initialValues={initialTransformationsValues}
+            searchResults={searchResults}
             autosize
             onSubmit={noop}
           />

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.css
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.css
@@ -1,0 +1,7 @@
+.searchGroupWrap {
+  margin-bottom: 0.5rem;
+}
+
+.filtersLabel {
+  padding-left: 1.3em;
+}

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.js
@@ -1,0 +1,90 @@
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import stripesFinalForm from '@folio/stripes/final-form';
+
+import {
+  SearchField,
+  AccordionSet,
+  Accordion,
+  FilterAccordionHeader,
+  Icon,
+  Button,
+} from '@folio/stripes/components';
+
+import { RecordTypeField } from '../../RecordTypeField';
+
+import css from './SearchForm.css';
+
+const SearchFormComponent = ({
+  values,
+  handleSubmit,
+  onFiltersChange,
+}) => {
+  const handleRecordTypeChange = useCallback((event, option) => {
+    const { recordTypes } = values.filters;
+
+    const nextFilters = event.target.checked
+      ? recordTypes.concat(option.value)
+      : recordTypes.filter(filter => filter !== option.value);
+
+    onFiltersChange('recordTypes', nextFilters);
+  }, [values.filters, onFiltersChange]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className={css.searchGroupWrap}>
+        <FormattedMessage id="ui-data-export.mappingProfiles.transformations.searchFields">
+          {label => (
+            <SearchField
+              data-test-transformations-search-field
+              aria-label={label}
+              autoFocus
+              marginBottom0
+            />
+          )}
+        </FormattedMessage>
+      </div>
+      <div>
+        <Button
+          data-test-transformations-reset
+          buttonStyle="none"
+        >
+          <Icon icon="times-circle-solid">
+            <FormattedMessage id="ui-data-export.resetAll" />
+          </Icon>
+        </Button>
+      </div>
+      <AccordionSet id="transformations-filter-accordions">
+        <Accordion
+          id="transformations-record-type-accordion"
+          header={FilterAccordionHeader}
+          label={<FormattedMessage id="ui-data-export.recordType" />}
+          separator={false}
+        >
+          <RecordTypeField
+            name="filters.recordTypes"
+            filtersLabelClass={css.filtersLabel}
+            onChange={handleRecordTypeChange}
+          />
+        </Accordion>
+      </AccordionSet>
+    </form>
+  );
+};
+
+SearchFormComponent.propTypes = {
+  values: PropTypes.shape({
+    filters: PropTypes.shape({ // eslint-disable-line object-curly-newline
+      recordTypes: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+    }).isRequired,
+  }).isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  onFiltersChange: PropTypes.func.isRequired,
+};
+
+export const SearchForm = stripesFinalForm({
+  subscription: { values: true },
+  navigationCheck: false,
+})(SearchFormComponent);

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/index.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/index.js
@@ -1,0 +1,1 @@
+export * from './SearchForm';

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
-import { isEqual } from 'lodash';
+import {
+  isEqual,
+  identity,
+} from 'lodash';
 
 import {
   TextField,
@@ -19,7 +22,10 @@ const columnWidths = {
 };
 const visibleColumns = ['isSelected', 'fieldName', 'transformation'];
 
-export const TransformationField = ({ autosize }) => {
+export const TransformationField = ({
+  autosize,
+  prepareData,
+}) => {
   const intl = useIntl();
 
   const formatter = {
@@ -70,7 +76,7 @@ export const TransformationField = ({ autosize }) => {
         <MultiColumnList
           id="mapping-profiles-form-transformations"
           fields={fields}
-          contentData={fields.value}
+          contentData={prepareData(fields.value)}
           totalCount={fields.value.length}
           columnMapping={columnMapping}
           columnWidths={columnWidths}
@@ -83,4 +89,9 @@ export const TransformationField = ({ autosize }) => {
   );
 };
 
-TransformationField.propTypes = { autosize: PropTypes.bool.isRequired };
+TransformationField.propTypes = {
+  autosize: PropTypes.bool.isRequired,
+  prepareData: PropTypes.func,
+};
+
+TransformationField.defaultProps = { prepareData: identity };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, {
+  memo,
+  useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
+import { intersectionWith } from 'lodash';
 
 import stripesFinalForm from '@folio/stripes/final-form';
 
@@ -7,21 +11,31 @@ import { TransformationField } from '../TransformationsField';
 
 import css from './TransformationsForm.css';
 
-const TransformationsFormComponent = ({
+const TransformationsFormComponent = memo(({
   autosize,
+  searchResults,
   handleSubmit,
 }) => {
+  const prepareData = useCallback(
+    results => intersectionWith(results, searchResults, (val1, val2) => val1.path === val2.path),
+    [searchResults],
+  );
+
   return (
     <form
       className={css.transformationsForm}
       onSubmit={handleSubmit}
     >
-      <TransformationField autosize={autosize} />
+      <TransformationField
+        autosize={autosize}
+        prepareData={prepareData}
+      />
     </form>
   );
-};
+});
 
 TransformationsFormComponent.propTypes = {
+  searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   autosize: PropTypes.bool,
 };

--- a/src/settings/MappingProfiles/RecordTypeField/RecordTypeField.js
+++ b/src/settings/MappingProfiles/RecordTypeField/RecordTypeField.js
@@ -1,0 +1,66 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { isEqual } from 'lodash';
+import { Field } from 'react-final-form';
+
+import { Checkbox } from '@folio/stripes/components';
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
+
+export const recordTypes = [
+  {
+    value: FOLIO_RECORD_TYPES.INSTANCE.type,
+    label: <FormattedMessage id={FOLIO_RECORD_TYPES.INSTANCE.captionId} />,
+  },
+  {
+    value: FOLIO_RECORD_TYPES.HOLDINGS.type,
+    label: <FormattedMessage id={FOLIO_RECORD_TYPES.HOLDINGS.captionId} />,
+  },
+  {
+    value: FOLIO_RECORD_TYPES.ITEM.type,
+    label: <FormattedMessage id={FOLIO_RECORD_TYPES.ITEM.captionId} />,
+  },
+];
+
+export const RecordTypeField = memo(({
+  id,
+  name,
+  filtersLabelClass,
+  onChange,
+}) => {
+  return (
+    <div
+      id={id}
+      data-test-record-type-fields
+    >
+      {recordTypes.map(option => (
+        <div key={option.value}>
+          <Field
+            name={name}
+            type="checkbox"
+            value={option.value}
+            isEqual={isEqual}
+            render={fieldProps => (
+              <Checkbox
+                {...fieldProps.input}
+                label={option.label}
+                innerClass={filtersLabelClass}
+                onChange={event => {
+                  onChange(event, option);
+                  fieldProps.input.onChange(event);
+                }}
+              />
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  );
+});
+
+RecordTypeField.propTypes = {
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  id: PropTypes.string,
+  filtersLabelClass: PropTypes.string,
+};

--- a/src/settings/MappingProfiles/RecordTypeField/index.js
+++ b/src/settings/MappingProfiles/RecordTypeField/index.js
@@ -1,0 +1,1 @@
+export * from './RecordTypeField';

--- a/test/bigtest/helpers/translationsProperties.js
+++ b/test/bigtest/helpers/translationsProperties.js
@@ -11,4 +11,12 @@ export const translationsProperties = [
     prefix: 'stripes-components',
     translations: stripesComponentsTranslations,
   },
+  {
+    prefix: 'stripes-smart-components',
+    translations: {
+      hideSearchPane: 'hideSearchPane',
+      showSearchPane: 'showSearchPane',
+      numberOfFilters: 'numberOfFilters',
+    },
+  },
 ];

--- a/test/bigtest/interactors/PaneInteractor.js
+++ b/test/bigtest/interactors/PaneInteractor.js
@@ -1,0 +1,11 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+// TODO: get rid of this interactor in advance of adding these fields to the pane interactor in stripes-components
+@interactor
+export class PaneInteractor {
+  headerTitle = scoped('[data-test-pane-header-title]');
+  subHeaderTitle = scoped('[data-test-pane-header-sub]');
+}

--- a/test/bigtest/interactors/index.js
+++ b/test/bigtest/interactors/index.js
@@ -5,4 +5,5 @@ export * from './jobs/JobsInteractor';
 export * from './jobs/RunningJobsInteractor';
 export * from './jobs/JobLogsContainerInteractor';
 export * from './jobs/allLogsPaneInteractor';
+export * from './PaneInteractor';
 export * from './settings';

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -44,10 +44,10 @@ describe('MappingProfilesForm', () => {
     await cleanup();
   });
 
-  describe('rendering mapping profiles form with stubbed submit handler', function () {
+  describe('rendering mapping profiles form with stubbed submit handler', () => {
     const handleSubmitSpy = sinon.spy();
 
-    beforeEach(async function () {
+    beforeEach(async () => {
       handleSubmitSpy.resetHistory();
 
       await mountWithContext(
@@ -236,13 +236,13 @@ describe('MappingProfilesForm', () => {
     });
   });
 
-  describe('rendering mapping profiles form with correct submit handler', function () {
+  describe('rendering mapping profiles form with correct submit handler', () => {
     let result;
     const name = 'Profile name';
     const description = 'Description value';
     const transformationValue = 'Transformation value 2';
 
-    beforeEach(async function () {
+    beforeEach(async () => {
       await mountWithContext(
         <Paneset>
           <Router>

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
@@ -23,11 +23,21 @@ const initialValues = {
     {
       displayName: 'Transformation field 1',
       transformation: 'Transformation value 1',
+      recordType: 'INSTANCE',
+      path: 'field1',
       order: 0,
     },
     {
       displayName: 'Transformation field 2',
+      recordType: 'ITEM',
+      path: 'field2',
       order: 1,
+    },
+    {
+      displayName: 'Transformation field 3',
+      recordType: 'HOLDINGS',
+      path: 'field3',
+      order: 2,
     },
   ],
 };
@@ -39,7 +49,7 @@ describe('MappingProfilesTransformationsModal', () => {
     await cleanup();
   });
 
-  describe('rendering mapping profiles form with stubbed submit handler', () => {
+  describe('rendering transformations modal', () => {
     beforeEach(async function () {
       await mountWithContext(
         <Router>
@@ -48,13 +58,7 @@ describe('MappingProfilesTransformationsModal', () => {
             initialTransformationsValues={initialValues}
           />
         </Router>,
-        [...translationsProperties, {
-          prefix: 'stripes-smart-components',
-          translations: {
-            hideSearchPane: 'hideSearchPane',
-            showSearchPane: 'showSearchPane',
-          },
-        }],
+        translationsProperties,
       );
     });
 
@@ -63,14 +67,14 @@ describe('MappingProfilesTransformationsModal', () => {
     });
 
     it('should display search pane', () => {
-      expect(modal.searchPane.isPresent).to.be.true;
-      expect(modal.searchPane.$('[data-test-pane-header-title]').innerText).to.equal(translations.searchAndFilter);
+      expect(modal.searchPane.isVisible).to.be.true;
+      expect(modal.searchPane.headerTitle.text).to.equal(translations.searchAndFilter);
     });
 
     it('should display results pane', () => {
       expect(modal.resultsPane.isPresent).to.be.true;
-      expect(modal.resultsPane.$('[data-test-pane-header-title]').innerText).to.equal(translations.transformations);
-      expect(modal.resultsPane.$('[data-test-pane-header-sub]').innerText).to.match(/\d+ fields found/);
+      expect(modal.resultsPane.headerTitle.text).to.equal(translations.transformations);
+      expect(modal.resultsPane.subHeaderTitle.text).to.equal(`${initialValues.transformations.length} fields found`);
     });
 
     it('should display filter accordions set', () => {
@@ -90,9 +94,9 @@ describe('MappingProfilesTransformationsModal', () => {
     });
 
     it('should display correct folio record types', () => {
-      expect(modal.recordTypeCheckboxes(0).label).to.equal(commonTranslations['recordTypes.instance']);
-      expect(modal.recordTypeCheckboxes(1).label).to.equal(commonTranslations['recordTypes.holdings']);
-      expect(modal.recordTypeCheckboxes(2).label).to.equal(commonTranslations['recordTypes.item']);
+      expect(modal.recordTypeFilters(0).label).to.equal(commonTranslations['recordTypes.instance']);
+      expect(modal.recordTypeFilters(1).label).to.equal(commonTranslations['recordTypes.holdings']);
+      expect(modal.recordTypeFilters(2).label).to.equal(commonTranslations['recordTypes.item']);
     });
 
     it('should display reset button', () => {
@@ -118,6 +122,10 @@ describe('MappingProfilesTransformationsModal', () => {
       expect(modal.expandSearchPaneButton.isPresent).to.be.false;
     });
 
+    it('should display correct amount of transformation fields', () => {
+      expect(modal.transformations.list.rowCount).to.equal(initialValues.transformations.length);
+    });
+
     it('should display correct transformation fields headers', () => {
       expect(modal.transformations.list.headers(0).$('[data-test-select-all-fields]')).to.not.be.undefined;
       expect(modal.transformations.list.headers(1).text).to.equal(translations['mappingProfiles.transformations.fieldName']);
@@ -139,7 +147,7 @@ describe('MappingProfilesTransformationsModal', () => {
       });
 
       it('should hide search pane', () => {
-        expect(modal.searchPane.isPresent).to.be.false;
+        expect(modal.searchPane.isVisible).to.be.false;
       });
 
       describe('clicking on expand search pane button', () => {
@@ -148,7 +156,35 @@ describe('MappingProfilesTransformationsModal', () => {
         });
 
         it('should display the search pane', () => {
-          expect(modal.searchPane.isPresent).to.be.true;
+          expect(modal.searchPane.isVisible).to.be.true;
+        });
+      });
+    });
+
+    describe('turning off certain record type filters', () => {
+      beforeEach(async () => {
+        await modal.recordTypeFilters(0).clickAndBlur();
+        await modal.recordTypeFilters(1).clickAndBlur();
+      });
+
+      it('should display correct amount of transformation fields', () => {
+        expect(modal.transformations.list.rowCount).to.equal(1);
+        expect(modal.resultsPane.subHeaderTitle.text).to.equal('1 field found');
+      });
+
+      it('should filter out the transformation list', () => {
+        expect(modal.transformations.list.rows(0).cells(1).text).to.equal('Transformation field 2');
+      });
+
+      describe('turning on filters again', () => {
+        beforeEach(async () => {
+          await modal.recordTypeFilters(0).clickAndBlur();
+          await modal.recordTypeFilters(1).clickAndBlur();
+        });
+
+        it('should display all transformation fields', () => {
+          expect(modal.transformations.list.rowCount).to.equal(initialValues.transformations.length);
+          expect(modal.resultsPane.subHeaderTitle.text).to.equal(`${initialValues.transformations.length} fields found`);
         });
       });
     });

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/TransformationsModalInteractor.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/interactors/TransformationsModalInteractor.js
@@ -8,19 +8,21 @@ import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interac
 import CheckboxInteractor from '@folio/stripes-components/lib/Checkbox/tests/interactor';
 import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
 import { AccordionSetInteractor } from '@folio/stripes-components/lib/Accordion/tests/interactor';
+
+import { PaneInteractor } from '../../../../../interactors';
 import { TransformationsInteractor } from './TransformationsInteractor';
 
 @interactor
 export class TransformationsModalInteractor {
   static defaultScope = '[data-test-transformations-modal]';
 
-  searchPane = new Interactor('[data-test-transformations-search-pane]');
+  searchPane = new PaneInteractor('[data-test-transformations-search-pane]');
   collapseSearchPaneButton = new Interactor('[data-test-collapse-filter-pane-button]');
   expandSearchPaneButton = new Interactor('[data-test-expand-filter-pane-button]');
-  resultsPane = new Interactor('[data-test-transformations-results-pane]');
+  resultsPane = new PaneInteractor('[data-test-transformations-results-pane]');
   filterAccordions = new AccordionSetInteractor('#transformations-filter-accordions');
   searchField = new TextFieldInteractor('[data-test-transformations-search-field]');
-  recordTypeCheckboxes = collection('#transformations-record-type-accordion [data-test-checkbox]', CheckboxInteractor);
+  recordTypeFilters = collection('#transformations-record-type-accordion [data-test-checkbox]', CheckboxInteractor);
   totalSelected = new Interactor('[data-test-transformations-total-selected]');
   saveButton = new ButtonInteractor('[data-test-transformations-save]');
   resetButton = new ButtonInteractor('[data-test-transformations-reset]');


### PR DESCRIPTION
## Purpose

Implement record type filter behavior in add mapping profile transformations modal in the scope of the [UIDEXP-69](https://issues.folio.org/browse/UIDEXP-69).

## Approach
- Move search form markup to its own `SearchForm` component;
- Move reusable logic for record type field to its own `RecordType` component;
- Reset filters upon modal closing;
- `MappingProfilesTransformationsModal` calculates `searchResults` so the subheader can display the proper amount of search results;
- Extend `TransformationsForm` with `searchResults` prop so filtering logic can be done;
- Filter pane visibility state is now done via CSS only so the filters state can be preserved when it is hidden and displayed again. Since `Pane` component does not properly deal with this, the `style` for this is conditionally applied to it `{...(!isFilterPaneOpen && fullWidthStyle)}`.

## Screenshots
<img width="1349" alt="Screen Shot 2020-07-28 at 3 18 07 PM" src="https://user-images.githubusercontent.com/40821852/88664349-a0146200-d0e5-11ea-902b-d564651ba0e2.png">

