### PR TITLE
UIDATIMP-535: Accommodate `FullScreenView` component usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Implement add mapping profile transformations modal. UIDEXP-104.
 * Add mapping profiles deleting. UIDEXP-133.
 * Implement record type filter behavior in add mapping profile transformations modal. UIDEXP-69.
+* Accommodate `FullScreenView` component usage according to [changes in stripes-data-transfer-components](https://github.com/folio-org/stripes-data-transfer-components/pull/88/files). UIDATIMP-535.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/src/settings/ProfileDetails/ProfileDetails.js
+++ b/src/settings/ProfileDetails/ProfileDetails.js
@@ -5,10 +5,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import {
-  ConfirmationModal,
-  Layer,
-} from '@folio/stripes/components';
+import { ConfirmationModal } from '@folio/stripes/components';
 import {
   FullScreenView,
   Preloader,
@@ -57,41 +54,37 @@ export const ProfileDetails = props => {
   return (
     <FormattedMessage id={`ui-data-export.${type}Profiles.newProfile`}>
       {contentLabel => (
-        <Layer
-          isOpen
+        <FullScreenView
+          id={`${type}-profile-details`}
           contentLabel={contentLabel}
+          paneTitle={profile?.name}
+          actionMenu={!isLoading && renderActionMenu}
+          onCancel={onCancel}
         >
-          <FullScreenView
-            id={`${type}-profile-details`}
-            paneTitle={profile?.name}
-            actionMenu={!isLoading && renderActionMenu}
-            onCancel={onCancel}
-          >
-            {isLoading
-              ? <Preloader />
-              : (
-                <>
-                  {children}
-                  <ConfirmationModal
-                    id={`delete-${type}-profile-confirmation-modal`}
-                    open={isConfirmationModalOpen}
-                    heading={<FormattedMessage id={`ui-data-export.${type}Profiles.delete.confirmationModal.title`} />}
-                    message={(
-                      <SafeHTMLMessage
-                        id={`ui-data-export.${type}Profiles.delete.confirmationModal.message`}
-                        values={{ name: profile.name }}
-                      />
-                    )}
-                    confirmLabel={<FormattedMessage id="ui-data-export.delete" />}
-                    cancelLabel={<FormattedMessage id="ui-data-export.cancel" />}
-                    onCancel={() => setConfirmationModalState(false)}
-                    onConfirm={() => handleDelete(profile)}
-                  />
-                </>
-              )
-            }
-          </FullScreenView>
-        </Layer>
+          {isLoading
+            ? <Preloader />
+            : (
+              <>
+                {children}
+                <ConfirmationModal
+                  id={`delete-${type}-profile-confirmation-modal`}
+                  open={isConfirmationModalOpen}
+                  heading={<FormattedMessage id={`ui-data-export.${type}Profiles.delete.confirmationModal.title`} />}
+                  message={(
+                    <SafeHTMLMessage
+                      id={`ui-data-export.${type}Profiles.delete.confirmationModal.message`}
+                      values={{ name: profile.name }}
+                    />
+                  )}
+                  confirmLabel={<FormattedMessage id="ui-data-export.delete" />}
+                  cancelLabel={<FormattedMessage id="ui-data-export.cancel" />}
+                  onCancel={() => setConfirmationModalState(false)}
+                  onConfirm={() => handleDelete(profile)}
+                />
+              </>
+            )
+          }
+        </FullScreenView>
       )}
     </FormattedMessage>
   );


### PR DESCRIPTION
## Purpose

Accommodate `FullScreenView` component usage according to [changes in stripes-data-transfer-components](https://github.com/folio-org/stripes-data-transfer-components/pull/88/files)l in the scope of the [UIDATIMP-535](https://issues.folio.org/browse/UIDATIMP-535).