### PR TITLE
UIDEXP-99: Cover closing functionality of mapping profile form by tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Implement transformations selection. UIDEXP-71.
 * Create code style guide document. UIDEXP-148.
 * Implement transformations saving. UIDEXP-73.
+* Cover closing functionality of mapping profile form by tests. UIDEXP-99.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -40,9 +40,11 @@ describe('MappingProfilesForm', () => {
 
   describe('rendering mapping profiles form with stubbed submit handler', () => {
     const handleSubmitSpy = sinon.spy();
+    const handleCloseSpy = sinon.spy();
 
     beforeEach(async () => {
       handleSubmitSpy.resetHistory();
+      handleCloseSpy.resetHistory();
 
       await mountWithContext(
         <>
@@ -52,7 +54,7 @@ describe('MappingProfilesForm', () => {
               <MappingProfilesFormContainer
                 initialValues={initialValues}
                 onSubmit={handleSubmitSpy}
-                onCancel={noop}
+                onCancel={handleCloseSpy}
               />
             </Router>
           </Paneset>
@@ -135,6 +137,26 @@ describe('MappingProfilesForm', () => {
 
       it('should enable save button if there are changes', () => {
         expect(form.fullScreen.submitButton.$root.disabled).to.be.false;
+      });
+
+      describe('clicking on close button', () => {
+        beforeEach(async () => {
+          await form.fullScreen.closeButton.click();
+        });
+
+        it('should call close handler', () => {
+          expect(handleCloseSpy.called).to.be.true;
+        });
+      });
+
+      describe('clicking on cancel button', () => {
+        beforeEach(async () => {
+          await form.fullScreen.cancelButton.click();
+        });
+
+        it('should call close handler', () => {
+          expect(handleCloseSpy.called).to.be.true;
+        });
       });
 
       describe('clicking on save button', () => {

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
@@ -8,7 +8,7 @@ import {
 } from '@bigtest/mocha';
 import { cleanup } from '@bigtest/react';
 import { expect } from 'chai';
-import { noop } from 'lodash';
+import sinon from 'sinon';
 
 import { mountWithContext } from '@folio/stripes-data-transfer-components/interactors';
 import stripesComponentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
@@ -62,12 +62,15 @@ const foundFieldsAmountMessage = fieldsAmount => {
 describe('MappingProfilesTransformationsModal', () => {
   const modal = new TransformationsModalInteractor();
   let submitResult;
+  const handleCloseSpy = sinon.spy();
 
   before(async () => {
     await cleanup();
   });
 
   describe('rendering transformations modal', () => {
+    handleCloseSpy.resetHistory();
+
     beforeEach(async () => {
       await mountWithContext(
         <Router>
@@ -75,7 +78,7 @@ describe('MappingProfilesTransformationsModal', () => {
             isOpen
             initialTransformationsValues={initialValues}
             onSubmit={selectedTransformations => { submitResult = selectedTransformations; }}
-            onCancel={noop}
+            onCancel={handleCloseSpy}
           />
         </Router>,
         translationsProperties,
@@ -146,6 +149,16 @@ describe('MappingProfilesTransformationsModal', () => {
       expect(modal.transformations.valuesFields(0).val).to.equal(initialValues.transformations[0].transformation);
       expect(modal.transformations.list.rows(1).cells(1).text).to.equal(initialValues.transformations[1].displayName);
       expect(modal.transformations.valuesFields(1).val).to.equal('');
+    });
+
+    describe('clicking on close button', () => {
+      beforeEach(async () => {
+        await modal.cancelButton.click();
+      });
+
+      it('should call close handler', () => {
+        expect(handleCloseSpy.called).to.be.true;
+      });
     });
 
     describe('saving filled and checked transformation', () => {


### PR DESCRIPTION
## Purposes

Add tests to cover closing functionality of mapping profile form. [Issue](https://issues.folio.org/browse/UIDEXP-99).