### PR TITLE
UIDEXP-138: Handle the case when form should be valid when no filled transformations are present

### DIFF
--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -4,7 +4,10 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty } from 'lodash';
+import {
+  isEmpty,
+  uniq,
+} from 'lodash';
 
 import {
   Layer,
@@ -18,20 +21,17 @@ import { mappingProfileTransformations } from '../MappingProfilesTransformations
 import { generateTransformationFieldsValues } from '../MappingProfilesTransformationsModal/TransformationsField';
 
 const isValidRecordTypesMatching = (selectedTransformations = [], selectedRecordTypes = []) => {
-  const recordTypesInFilledTransformations = [];
+  if (isEmpty(selectedTransformations)) {
+    return true;
+  }
 
-  selectedTransformations.forEach(({
-    recordType,
-    transformation,
-  }) => {
-    if (transformation && !recordTypesInFilledTransformations.includes(recordType)) {
-      recordTypesInFilledTransformations.push(recordType);
-    }
-  });
+  const filledSelectedTransformations = selectedTransformations.filter(filledSelectedTransformation => filledSelectedTransformation.transformation);
+
+  const recordTypesInTransformations = uniq(filledSelectedTransformations.map(({ recordType }) => recordType));
 
   const recordTypesDifference = selectedRecordTypes
-    .filter(recordType => !recordTypesInFilledTransformations.includes(recordType))
-    .concat(recordTypesInFilledTransformations.filter(recordType => !selectedRecordTypes.includes(recordType)));
+    .filter(recordType => !recordTypesInTransformations.includes(recordType))
+    .concat(recordTypesInTransformations.filter(recordType => !selectedRecordTypes.includes(recordType)));
 
   return isEmpty(recordTypesDifference);
 };

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -207,8 +207,24 @@ describe('MappingProfilesForm', () => {
                 await form.fullScreen.submitButton.click();
               });
 
-              it('should display record types mismatch message', () => {
-                expect(form.summary.recordType.errorLabel).to.equal(translations['mappingProfiles.validation.recordTypeMismatch']);
+              it('should not display record types mismatch message when no transformations are provided', () => {
+                expect(form.summary.recordType.errorLabel).to.equal('');
+              });
+
+              describe('filling transformation which does not match the selected record typ and submitting the form', () => {
+                beforeEach(async () => {
+                  await form.addTransformationButton.click();
+                  await wait();
+                  await form.transformationsModal.transformations.valuesFields(0).fillAndBlur('Custom value');
+                  await form.transformationsModal.transformations.checkboxes(0).clickInput();
+                  await form.transformationsModal.saveButton.click();
+                  await wait();
+                  await form.fullScreen.submitButton.click();
+                });
+
+                it('should display record types mismatch message', () => {
+                  expect(form.summary.recordType.errorLabel).to.equal(translations['mappingProfiles.validation.recordTypeMismatch']);
+                });
               });
             });
           });


### PR DESCRIPTION
## Purpose

Handle the case when form should be valid when no filled transformations are present in the scope of the [UIDEXP-138](https://issues.folio.org/browse/UIDEXP-138).