### PR TITLE
UIDEXP-18: Implement transtion to error logs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Accommodate UI to the change for the retrieving of job logs API endpoint. UIDEXP-145.
 * Implement mapping profile transformations editing. UIDEXP-131.
 * Provide translations for the mapping profile transformation field names. UIDEXP-159.
+* Implement transition to error logs page. UIDEXP-18.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/src/components/ErrorLogsView/ErrorLogsView.js
+++ b/src/components/ErrorLogsView/ErrorLogsView.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { OverlayView } from '@folio/stripes-data-transfer-components';
+
+export const ErrorLogsView = () => {
+  return (
+    <OverlayView>
+      <span>Logs list</span>
+    </OverlayView>
+  );
+};

--- a/src/components/ErrorLogsView/index.js
+++ b/src/components/ErrorLogsView/index.js
@@ -1,0 +1,1 @@
+export * from './ErrorLogsView';

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -112,11 +112,22 @@ const JobLogsContainer = props => {
         buttonStyle="link"
         marginBottom0
         buttonClass={styles.fileNameBtn}
-        onClick={() => downloadExportFile(record)}
+        onClick={e => {
+          e.stopPropagation();
+          downloadExportFile(record);
+        }}
       >
         {fileName}
       </Button>
     );
+  };
+
+  const handleRowClick = (e, row) => {
+    if (row?.progress?.failed) {
+      const path = `/data-export/log/${row.id}`;
+
+      window.open(path, '_blank').focus();
+    }
   };
 
   const intl = useIntl();
@@ -138,6 +149,7 @@ const JobLogsContainer = props => {
         sortColumns={sortColumns}
         hasLoaded={hasLoaded}
         contentData={logs}
+        onRowClick={handleRowClick}
         {...useJobLogsProperties(customProperties)}
       />
       <Callout ref={calloutRef} />

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { Pane } from '@folio/stripes/components';
 import { DataExportSettings } from './settings';
 import Home from './routes/Home';
 import ChooseJobProfile from './components/ChooseJobProfile';
+import { ErrorLogsView } from './components/ErrorLogsView';
 
 export default function DataExport(props) {
   const {
@@ -48,6 +49,10 @@ export default function DataExport(props) {
       <Route
         path={`${path}/job-profile`}
         component={ChooseJobProfile}
+      />
+      <Route
+        paty={`${path}/log/:id`}
+        component={ErrorLogsView}
       />
     </Switch>
   );

--- a/test/bigtest/tests/errorLogs-test.js
+++ b/test/bigtest/tests/errorLogs-test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+
+import { OverlayViewInteractor } from '@folio/stripes-data-transfer-components/interactors';
+import { setupApplication } from '../helpers';
+
+describe('Error logs', () => {
+  const overlayViewInteractor = new OverlayViewInteractor();
+
+  setupApplication([]);
+
+  describe('visiting error logs page', () => {
+    beforeEach(function () {
+      this.visit('/data-export/log/log-id');
+    });
+
+    it('should display overlay view', () => {
+      expect(overlayViewInteractor.isPresent).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Purposes

Add transition to the error logs view on job logs item click (if there are errors). [Story](https://issues.folio.org/browse/UIDEXP-180)

**Note**: There are no ways to cover the transtion to the new tab using BigTest.