### PR TITLE
UIDEXP-166: Fix mapping profile form validation in case of empty transformation values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Implement view all logs list. UIDEXP-142.
 * Rearrange columns order in Logs table. UIDEXP-150.
 * Update `react-intl` to `v5.7.0`. UIDEXP-157.
+* Fix mapping profile form validation in case of not filled transformation values.UIDEXP-166.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -28,9 +28,7 @@ const isValidRecordTypesMatching = (selectedTransformations = [], selectedRecord
     return true;
   }
 
-  const filledSelectedTransformations = selectedTransformations
-    .filter(filledSelectedTransformation => filledSelectedTransformation.transformation);
-  const recordTypesInTransformations = uniq(filledSelectedTransformations.map(({ recordType }) => recordType));
+  const recordTypesInTransformations = uniq(selectedTransformations.map(({ recordType }) => recordType));
 
   return isEmpty(difference(recordTypesInTransformations, selectedRecordTypes))
     && isEmpty(difference(selectedRecordTypes, recordTypesInTransformations));


### PR DESCRIPTION
## Purposes

Fix mapping profile form validation in case of empty transformation values. Now this case should be marked as valid. [Issue](https://issues.folio.org/browse/UIDEXP-166).

## Screenshots

![Screenshot 2020-10-07 at 16 31 57](https://user-images.githubusercontent.com/50317804/95337858-f575a800-08ba-11eb-8f72-b2dfe0e0b2a1.png)

![Screenshot 2020-10-07 at 16 32 01](https://user-images.githubusercontent.com/50317804/95337866-f73f6b80-08ba-11eb-8966-9a3a122bfd2c.png)
