### PR TITLE
UIDEXP-162: Fix mapping profile transformations form not being sorted when created via API

### DIFF
--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -9,6 +9,7 @@ import { FormattedMessage } from 'react-intl';
 import {
   get,
   noop,
+  orderBy,
 } from 'lodash';
 
 import {
@@ -59,6 +60,7 @@ export const MappingProfilesTransformationsModal = ({
   const [searchValue, setSearchValue] = useState(initialSearchFormValues.searchValue);
   const [searchFilters, setSearchFilters] = useState(initialSearchFormValues.filters);
   const [selectedTransformations, setSelectedTransformations] = useState(initialSelectedTransformations);
+  const [sortedInitialTransformationsValues, setSortedInitialTransformationsValues] = useState(initialTransformationsValues);
   const transformationsFormStateRef = useRef(null);
 
   const resetSearchForm = useCallback(() => {
@@ -74,8 +76,8 @@ export const MappingProfilesTransformationsModal = ({
   }, [isOpen, resetSearchForm]);
 
   const searchValueResults = !searchValue
-    ? initialTransformationsValues.transformations
-    : initialTransformationsValues.transformations
+    ? sortedInitialTransformationsValues.transformations
+    : sortedInitialTransformationsValues.transformations
       .filter(value => value.displayName.toLowerCase().includes(searchValue));
 
   const searchResults = [];
@@ -125,6 +127,12 @@ export const MappingProfilesTransformationsModal = ({
 
     onSubmit(normalizedTransformations);
   };
+
+  useEffect(() => {
+    const transformations = orderBy(initialTransformationsValues.transformations, 'displayName', 'asc');
+
+    setSortedInitialTransformationsValues({ transformations });
+  }, [initialTransformationsValues]);
 
   const renderFooter = () => {
     return (
@@ -199,7 +207,7 @@ export const MappingProfilesTransformationsModal = ({
           <TransformationsForm
             id="transformations-form"
             stateRef={transformationsFormStateRef}
-            initialValues={initialTransformationsValues}
+            initialValues={sortedInitialTransformationsValues}
             searchResults={searchResults}
             isSelectAllChecked={displayedCheckedItemsAmount === searchResults.length}
             onSelectChange={handleSelectChange}

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -9,7 +9,6 @@ import { FormattedMessage } from 'react-intl';
 import {
   get,
   noop,
-  orderBy,
 } from 'lodash';
 
 import {
@@ -60,7 +59,6 @@ export const MappingProfilesTransformationsModal = ({
   const [searchValue, setSearchValue] = useState(initialSearchFormValues.searchValue);
   const [searchFilters, setSearchFilters] = useState(initialSearchFormValues.filters);
   const [selectedTransformations, setSelectedTransformations] = useState(initialSelectedTransformations);
-  const [sortedInitialTransformationsValues, setSortedInitialTransformationsValues] = useState(initialTransformationsValues);
   const transformationsFormStateRef = useRef(null);
 
   const resetSearchForm = useCallback(() => {
@@ -76,8 +74,8 @@ export const MappingProfilesTransformationsModal = ({
   }, [isOpen, resetSearchForm]);
 
   const searchValueResults = !searchValue
-    ? sortedInitialTransformationsValues.transformations
-    : sortedInitialTransformationsValues.transformations
+    ? initialTransformationsValues.transformations
+    : initialTransformationsValues.transformations
       .filter(value => value.displayName.toLowerCase().includes(searchValue));
 
   const searchResults = [];
@@ -127,12 +125,6 @@ export const MappingProfilesTransformationsModal = ({
 
     onSubmit(normalizedTransformations);
   };
-
-  useEffect(() => {
-    const transformations = orderBy(initialTransformationsValues.transformations, 'displayName', 'asc');
-
-    setSortedInitialTransformationsValues({ transformations });
-  }, [initialTransformationsValues]);
 
   const renderFooter = () => {
     return (
@@ -207,7 +199,7 @@ export const MappingProfilesTransformationsModal = ({
           <TransformationsForm
             id="transformations-form"
             stateRef={transformationsFormStateRef}
-            initialValues={sortedInitialTransformationsValues}
+            initialValues={initialTransformationsValues}
             searchResults={searchResults}
             isSelectAllChecked={displayedCheckedItemsAmount === searchResults.length}
             onSelectChange={handleSelectChange}

--- a/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
+++ b/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
@@ -1,11 +1,6 @@
-import React, {
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { orderBy } from 'lodash';
 
 import { MultiColumnList } from '@folio/stripes/components';
 
@@ -21,7 +16,6 @@ export const TransformationsList = ({
   transformations,
   allTransformations,
 }) => {
-  const [sortedTransformations, setSortedTransformations] = useState([]);
   const intl = useIntl();
 
   const formatter = useMemo(() => ({
@@ -45,22 +39,14 @@ export const TransformationsList = ({
     transformation: intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.transformation' }),
   }), [intl]);
 
-  useEffect(() => {
-    const formattedTransformations = transformations.map(transformation => ({
-      fieldName: formatter.fieldName(transformation),
-      transformation: formatter.transformation(transformation),
-    }));
-
-    setSortedTransformations(orderBy(formattedTransformations, 'fieldName', 'asc'));
-  }, [transformations, formatter]);
-
   return (
     <MultiColumnList
       id="mapping-profile-transformations-list"
-      contentData={sortedTransformations}
+      contentData={transformations}
       columnMapping={columnMapping}
       columnWidths={columnWidths}
       visibleColumns={visibleColumns}
+      formatter={formatter}
       isEmptyMessage={intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.emptyMessage' })}
     />
   );

--- a/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
+++ b/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
@@ -1,6 +1,11 @@
-import React, { useMemo } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { orderBy } from 'lodash';
 
 import { MultiColumnList } from '@folio/stripes/components';
 
@@ -16,6 +21,7 @@ export const TransformationsList = ({
   transformations,
   allTransformations,
 }) => {
+  const [sortedTransformations, setSortedTransformations] = useState([]);
   const intl = useIntl();
 
   const formatter = useMemo(() => ({
@@ -39,14 +45,22 @@ export const TransformationsList = ({
     transformation: intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.transformation' }),
   }), [intl]);
 
+  useEffect(() => {
+    const formattedTransformations = transformations.map(transformation => ({
+      fieldName: formatter.fieldName(transformation),
+      transformation: formatter.transformation(transformation),
+    }));
+
+    setSortedTransformations(orderBy(formattedTransformations, 'fieldName', 'asc'));
+  }, [transformations, formatter]);
+
   return (
     <MultiColumnList
       id="mapping-profile-transformations-list"
-      contentData={transformations}
+      contentData={sortedTransformations}
       columnMapping={columnMapping}
       columnWidths={columnWidths}
       visibleColumns={visibleColumns}
-      formatter={formatter}
       isEmptyMessage={intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.emptyMessage' })}
     />
   );

--- a/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
+++ b/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
@@ -1,6 +1,11 @@
-import React, { useMemo } from 'react';
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { orderBy } from 'lodash';
 
 import { MultiColumnList } from '@folio/stripes/components';
 
@@ -16,6 +21,7 @@ export const TransformationsList = ({
   transformations,
   allTransformations,
 }) => {
+  const [sortedTransformations, setSortedTransformations] = useState([]);
   const intl = useIntl();
 
   const formatter = useMemo(() => ({
@@ -39,14 +45,22 @@ export const TransformationsList = ({
     transformation: intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.transformation' }),
   }), [intl]);
 
+  useEffect(() => {
+    const formattedTransformations = orderBy(transformations.map(transformation => ({
+      fieldName: formatter.fieldName(transformation),
+      transformation: formatter.transformation(transformation),
+    })), 'fieldName', 'asc');
+
+    setSortedTransformations(formattedTransformations);
+  }, [transformations, formatter]);
+
   return (
     <MultiColumnList
       id="mapping-profile-transformations-list"
-      contentData={transformations}
+      contentData={sortedTransformations}
       columnMapping={columnMapping}
       columnWidths={columnWidths}
       visibleColumns={visibleColumns}
-      formatter={formatter}
       isEmptyMessage={intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.emptyMessage' })}
     />
   );


### PR DESCRIPTION
## Purpose

After implementing [UIDEXP-162](https://issues.folio.org/browse/UIDEXP-162) a bug was found, when mapping profile transformations form was not sorted, when mapping profile was created via API call. 

## Screenshots

Mapping profile that was created via API call
![image](https://user-images.githubusercontent.com/69502158/95742492-c5eae500-0c98-11eb-94a3-4eb4e418ecd0.png)
