### PR TITLE
UIDEXP-175: Fix date and time display in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Update `react-intl` to `v5.7.0`. UIDEXP-157.
 * Fix mapping profile form validation in case of not filled transformation values.UIDEXP-166.
 * Alphabetically order field names on the transformations form. UIDEXP-162.
+* Fix date and time display in Safari. UIDEXP-175.
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
+++ b/src/components/Jobs/RunningJobs/JobDetails/JobDetails.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import {
-  FormattedMessage,
-  FormattedTime,
-  FormattedDate,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { get } from 'lodash';
 
+import {
+  FormattedTime,
+  FormattedDate,
+} from '@folio/stripes/components';
 import {
   jobExecutionPropTypes,
   Progress,


### PR DESCRIPTION
## Purposes

Fix date and time display in Safari using FormattedDate and FormattedTime components from stripes-components instead of react-intil. [Story](https://issues.folio.org/browse/UIDEXP-175).

## Screenshots

![Screenshot 2020-10-12 at 16 55 13](https://user-images.githubusercontent.com/50317804/95754460-bd4fda00-0cab-11eb-9d60-a2fed9f11c51.png)
