### PR TITLE
UIDEXP-173: Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-data-export
 
-## 3.0.0 (IN PROGRESS)
+## 3.1.0 (IN PROGRESS)
+
+## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
+[Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)
 * Add translations for permission names. UIDEXP-76.
 * Fix accessibility string building for MCL components. UIDEXP-117.
 * Implement mapping profile details action menu. UIDEXP-75.
@@ -38,6 +41,7 @@
 * Fix date and time display in Safari. UIDEXP-175.
 * Implement support of triggering export using CQL query files. UIDEXP-156.
 * Render error logs details on the error logs page. UIDEXP-144.
+* Update translations
 
 ## [2.0.1](https://github.com/folio-org/ui-data-export/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.0...v2.0.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-export",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Data export manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-export",
@@ -44,7 +44,7 @@
     "sinon": "^7.1.1"
   },
   "dependencies": {
-    "@folio/stripes-data-transfer-components": "^2.0.0",
+    "@folio/stripes-data-transfer-components": "^3.0.0",
     "classnames": "^2.2.5",
     "lodash": "^4.16.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
## Purpose

Release v3.0.0 of ui-data-export in the scope of [UIDEXP-173](https://issues.folio.org/browse/UIDEXP-173).