### PR TITLE
UIDEXP-167: Fix Save & Close button on the Edit mapping profile page not closing the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-data-export
 
 ## 3.1.0 (IN PROGRESS)
+* Fix `Save & Close` button on the Edit mapping profile page not closing the profile. UIDEXP-167.
 
 ## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)

--- a/src/settings/JobProfiles/CreateJobProfileRoute/CreateJobProfileRoute.js
+++ b/src/settings/JobProfiles/CreateJobProfileRoute/CreateJobProfileRoute.js
@@ -28,7 +28,7 @@ const CreateJobProfileRouteComponent = props => {
     errorMessageId: 'ui-data-export.jobProfiles.create.errorCallout',
     successMessageId: 'ui-data-export.jobProfiles.create.successCallout',
     onAction: onSubmit,
-    onCancel,
+    onActionComplete: onCancel,
   });
 
   return (

--- a/src/settings/MappingProfiles/CreateMappingProfileFormRoute/CreateMappingProfileFormRoute.js
+++ b/src/settings/MappingProfiles/CreateMappingProfileFormRoute/CreateMappingProfileFormRoute.js
@@ -17,7 +17,7 @@ export const CreateMappingProfileFormRoute = ({
     errorMessageId: 'ui-data-export.mappingProfiles.create.errorCallout',
     successMessageId: 'ui-data-export.mappingProfiles.create.successCallout',
     onAction: onSubmit,
-    onCancel: onSubmitNavigate,
+    onActionComplete: onSubmitNavigate,
   });
 
   return (

--- a/src/settings/MappingProfiles/EditMappingProfileRoute/EditMappingProfileRoute.js
+++ b/src/settings/MappingProfiles/EditMappingProfileRoute/EditMappingProfileRoute.js
@@ -15,7 +15,7 @@ export const EditMappingProfileRouteComponent = ({
   mutator,
   allTransformations,
   onCancel,
-  onSave,
+  onSubmitNavigate,
 }) => {
   const intl = useIntl();
   const contentLabel = intl.formatMessage({ id: 'ui-data-export.mappingProfiles.editProfile' });
@@ -25,7 +25,7 @@ export const EditMappingProfileRouteComponent = ({
     successMessageId: 'ui-data-export.mappingProfiles.edit.successCallout',
     isCanceledAfterError: true,
     onAction: mutator.mappingProfile.PUT,
-    onActionComplete: onSave,
+    onActionComplete: onSubmitNavigate,
   });
 
   const mappingProfileRecord = get(mappingProfile, 'records.0');
@@ -66,7 +66,7 @@ EditMappingProfileRouteComponent.propTypes = {
   mutator: PropTypes.shape({ mappingProfile: PropTypes.shape({ PUT: PropTypes.func.isRequired }) }).isRequired,
   allTransformations: PropTypes.arrayOf(PropTypes.object),
   onCancel: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired,
+  onSubmitNavigate: PropTypes.func.isRequired,
 };
 
 export const EditMappingProfileRoute = stripesConnect(EditMappingProfileRouteComponent);

--- a/src/settings/MappingProfiles/EditMappingProfileRoute/EditMappingProfileRoute.js
+++ b/src/settings/MappingProfiles/EditMappingProfileRoute/EditMappingProfileRoute.js
@@ -15,6 +15,7 @@ export const EditMappingProfileRouteComponent = ({
   mutator,
   allTransformations,
   onCancel,
+  onSave,
 }) => {
   const intl = useIntl();
   const contentLabel = intl.formatMessage({ id: 'ui-data-export.mappingProfiles.editProfile' });
@@ -24,7 +25,7 @@ export const EditMappingProfileRouteComponent = ({
     successMessageId: 'ui-data-export.mappingProfiles.edit.successCallout',
     isCanceledAfterError: true,
     onAction: mutator.mappingProfile.PUT,
-    onCancel,
+    onActionComplete: onSave,
   });
 
   const mappingProfileRecord = get(mappingProfile, 'records.0');
@@ -65,6 +66,7 @@ EditMappingProfileRouteComponent.propTypes = {
   mutator: PropTypes.shape({ mappingProfile: PropTypes.shape({ PUT: PropTypes.func.isRequired }) }).isRequired,
   allTransformations: PropTypes.arrayOf(PropTypes.object),
   onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };
 
 export const EditMappingProfileRoute = stripesConnect(EditMappingProfileRouteComponent);

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -131,8 +131,8 @@ const MappingProfilesContainer = ({
               <EditMappingProfileRoute
                 {...editPageProps}
                 allTransformations={allTransformations}
-                onCancel={handleEditPageCancel}
-                onSave={handleNavigationToMappingProfilesList}
+                onCancel={handleNavigationToMappingProfilesList}
+                onSubmitNavigate={handleNavigationToMappingProfilesList}
               />
             </FullScreenPreloader>
           );

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -132,6 +132,7 @@ const MappingProfilesContainer = ({
                 {...editPageProps}
                 allTransformations={allTransformations}
                 onCancel={handleEditPageCancel}
+                onSave={handleNavigationToMappingProfilesList}
               />
             </FullScreenPreloader>
           );

--- a/src/settings/ProfileDetails/ProfileDetails.js
+++ b/src/settings/ProfileDetails/ProfileDetails.js
@@ -39,7 +39,7 @@ export const ProfileDetails = props => {
     successMessageId: `ui-data-export.${type}Profiles.delete.successCallout`,
     isCanceledAfterError: true,
     onAction: onDelete,
-    onCancel: () => {
+    onActionComplete: () => {
       setConfirmationModalState(false);
 
       onCancel();

--- a/src/settings/utils/useProfileHandlerWithCallout.js
+++ b/src/settings/utils/useProfileHandlerWithCallout.js
@@ -6,7 +6,7 @@ import { CalloutContext } from '@folio/stripes/core';
 export const useProfileHandlerWithCallout = ({
   errorMessageId,
   successMessageId,
-  onCancel,
+  onActionComplete,
   onAction,
   isCanceledAfterError = false,
 }) => {
@@ -23,7 +23,7 @@ export const useProfileHandlerWithCallout = ({
         />,
       });
 
-      onCancel();
+      onActionComplete();
     } catch {
       callout.sendCallout({
         message: <SafeHTMLMessage
@@ -34,7 +34,7 @@ export const useProfileHandlerWithCallout = ({
       });
 
       if (isCanceledAfterError) {
-        onCancel();
+        onActionComplete();
       }
     }
   };

--- a/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
@@ -41,6 +41,7 @@ function EditMappingProfileRouteContainer({
   mutator = { PUT: noop },
   sendCallout = noop,
   onCancel = noop,
+  onSave = noop,
 } = {}) {
   const intl = useIntl();
 
@@ -58,6 +59,7 @@ function EditMappingProfileRouteContainer({
             })}
             mutator={buildMutator({ mappingProfile: mutator })}
             onCancel={onCancel}
+            onSave={onSave}
           />
         </CalloutContext.Provider>
       </Paneset>
@@ -88,11 +90,13 @@ describe('EditMappingProfileRoute', () => {
   describe('rendering edit mapping profile page with profile data: success scenario', () => {
     let handleSubmitSpy;
     let handleCancelSpy;
+    let handleSaveSpy;
     let sendCalloutStub;
 
     beforeEach(async () => {
       handleSubmitSpy = sinon.stub().callsFake(Promise.resolve.bind(Promise));
       handleCancelSpy = sinon.spy();
+      handleSaveSpy = sinon.spy();
       sendCalloutStub = sinon.spy();
 
       await mountWithContext(
@@ -101,6 +105,7 @@ describe('EditMappingProfileRoute', () => {
           mutator={{ PUT: handleSubmitSpy }}
           sendCallout={sendCalloutStub}
           onCancel={handleCancelSpy}
+          onSave={handleSaveSpy}
         />,
         translationsProperties,
       );
@@ -180,8 +185,8 @@ describe('EditMappingProfileRoute', () => {
           expect(sendCalloutStub.firstCall.args[0].message.props.id).to.equal('ui-data-export.mappingProfiles.edit.successCallout');
         });
 
-        it('should call cancel callback', () => {
-          expect(handleCancelSpy.calledOnce).to.be.true;
+        it('should call save callback', () => {
+          expect(handleSaveSpy.calledOnce).to.be.true;
         });
       });
 
@@ -199,8 +204,8 @@ describe('EditMappingProfileRoute', () => {
           expect(sendCalloutStub.calledWith(sinon.match({ type: 'error' })));
         });
 
-        it('should call cancel callback', () => {
-          expect(handleCancelSpy.calledOnce).to.be.true;
+        it('should call save callback', () => {
+          expect(handleSaveSpy.calledOnce).to.be.true;
         });
       });
     });

--- a/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
@@ -41,7 +41,7 @@ function EditMappingProfileRouteContainer({
   mutator = { PUT: noop },
   sendCallout = noop,
   onCancel = noop,
-  onSave = noop,
+  onSubmitNavigate = noop,
 } = {}) {
   const intl = useIntl();
 
@@ -59,7 +59,7 @@ function EditMappingProfileRouteContainer({
             })}
             mutator={buildMutator({ mappingProfile: mutator })}
             onCancel={onCancel}
-            onSave={onSave}
+            onSubmitNavigate={onSubmitNavigate}
           />
         </CalloutContext.Provider>
       </Paneset>
@@ -105,7 +105,7 @@ describe('EditMappingProfileRoute', () => {
           mutator={{ PUT: handleSubmitSpy }}
           sendCallout={sendCalloutStub}
           onCancel={handleCancelSpy}
-          onSave={handleSaveSpy}
+          onSubmitNavigate={handleSaveSpy}
         />,
         translationsProperties,
       );


### PR DESCRIPTION
[[UIDEXP-167]](https://issues.folio.org/browse/UIDEXP-167)

## Purpose 
After clicking `Save & Close` button on Edit mapping profile page it should close the mapping profile details page and navigate to mapping profile list.

![UIDEXP-167](https://user-images.githubusercontent.com/69502158/96441489-474ef400-1212-11eb-8d73-0fdabbbfc725.gif)
