### PR TITLE
UIDEXP-182: Fix inability to view error logs for an empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0 (IN PROGRESS)
 * Fix `Save & Close` button on the Edit mapping profile page not closing the profile. UIDEXP-167.
+* Fix inability to view error logs for an empty file. UIDEXP-182.
 
 ## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -21,6 +21,7 @@ import { useStripes } from '@folio/stripes/core';
 
 import {
   DEFAULT_JOB_LOG_COLUMNS,
+  JOB_EXECUTION_STATUSES,
   downloadFileByLink,
 } from '../../utils';
 import getFileDownloadLink from './fetchFileDownloadLink';
@@ -100,7 +101,7 @@ export const JobLogsContainer = props => {
   };
 
   const handleRowClick = (e, row) => {
-    if (row?.progress?.failed) {
+    if (row?.status !== JOB_EXECUTION_STATUSES.COMPLETED) {
       const path = `/data-export/log/${row.id}`;
 
       window.open(path, '_blank').focus();

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -101,7 +101,7 @@ export const JobLogsContainer = props => {
   };
 
   const handleRowClick = (e, row) => {
-    if (row?.status !== JOB_EXECUTION_STATUSES.COMPLETED) {
+    if (row.status !== JOB_EXECUTION_STATUSES.COMPLETED) {
       const path = `/data-export/log/${row.id}`;
 
       window.open(path, '_blank').focus();

--- a/test/bigtest/network/scenarios/fetch-job-executions-success.js
+++ b/test/bigtest/network/scenarios/fetch-job-executions-success.js
@@ -30,6 +30,7 @@ export const runningJobExecutions = [
 export const logJobExecutions = [
   {
     hrId: 2,
+    id: 'c92c6c12-82fc-42b9-b445-c530f24582b9',
     exportedFiles: [{ fileName: 'import-1.mrc' }],
     progress: { total: 500 },
     runBy: {
@@ -42,6 +43,7 @@ export const logJobExecutions = [
   },
   {
     hrId: 3,
+    id: '5d535173-0914-40c2-a9fa-96eea64ceed7',
     exportedFiles: [{ fileName: 'import-2.mrc' }],
     progress: {
       exported: 4990,
@@ -58,6 +60,7 @@ export const logJobExecutions = [
   },
   {
     hrId: 1,
+    id: '1bd03301-d9d5-4e0e-bc04-aea8065a3f86',
     exportedFiles: [{ fileName: 'import-3.mrc' }],
     progress: {
       exported: 500,

--- a/test/bigtest/tests/jobLogs-test.js
+++ b/test/bigtest/tests/jobLogs-test.js
@@ -4,6 +4,7 @@ import {
   beforeEach,
   it,
 } from '@bigtest/mocha';
+import sinon from 'sinon';
 
 import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 import translations from '../../../translations/ui-data-export/en';
@@ -144,6 +145,49 @@ describe('Job logs list', () => {
 
       it('should not show error notification', () => {
         expect(jobLogsContainerInteractor.callout.errorCalloutIsPresent).to.be.false;
+      });
+    });
+
+    describe('clicking on a row', () => {
+      const windowOpenStub = sinon.stub(window, 'open').returns({ focus: sinon.stub() });
+
+      describe('with failed status', () => {
+        beforeEach(async () => {
+          await jobLogsContainerInteractor.logsList.rows(1).click();
+        });
+
+        it('should open error log', () => {
+          const [url, blank] = windowOpenStub.getCall(0).args;
+
+          expect(url).to.equal(`/data-export/log/${logJobExecutions[0].id}`);
+          expect(blank).to.equal('_blank');
+          windowOpenStub.resetHistory();
+        });
+      });
+
+      describe('with completed with errors status', () => {
+        beforeEach(async () => {
+          await jobLogsContainerInteractor.logsList.rows(0).click();
+        });
+
+        it('should open error log', () => {
+          const [url, blank] = windowOpenStub.getCall(0).args;
+
+          expect(url).to.equal(`/data-export/log/${logJobExecutions[1].id}`);
+          expect(blank).to.equal('_blank');
+          windowOpenStub.resetHistory();
+        });
+      });
+
+      describe('with completed status', () => {
+        beforeEach(async () => {
+          await jobLogsContainerInteractor.logsList.rows(2).click();
+        });
+
+        it('should not open error log', () => {
+          expect(windowOpenStub.called).to.be.false;
+          windowOpenStub.restore();
+        });
       });
     });
   });


### PR DESCRIPTION
[[UIDEXP-182]](https://issues.folio.org/browse/UIDEXP-182)

## Purpose
The user was unable to view error logs for job, that was triggered by an empty file.