### PR TITLE
UIDEXP-179: Setup jest/react-testing-library and cover `ChooseJobProfile` component and util methods with tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@
   "globals": {
     "process": true
   },
+  "env": {
+    "jest/globals": true
+  },
   "extends": "@folio/eslint-config-stripes",
   "parser": "babel-eslint",
   "parserOptions": {
@@ -9,7 +12,7 @@
       "legacyDecorators": true
     }
   },
-  "plugins": ["babel"],
+  "plugins": ["babel", "jest"],
   "root": true,
   "rules": {
     "key-spacing": [

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 package-lock.json
 yarn.lock
+junit.xml
 
 # Logs
 logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix `Save & Close` button on the Edit mapping profile page not closing the profile. UIDEXP-167.
 * Fix inability to view error logs for an empty file. UIDEXP-182.
 * Setup jest/react-testing-library and cover `ChooseJobProfile` component and util methods with tests. UIDEXP-179.
+* Adjust `ui-data-export` after the change in the `JobsListAccordion` in `stripes-data-transfer-components` with regard to data-test attribute. UIDATIMP-574.
 
 ## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 (IN PROGRESS)
 * Fix `Save & Close` button on the Edit mapping profile page not closing the profile. UIDEXP-167.
 * Fix inability to view error logs for an empty file. UIDEXP-182.
+* Setup jest/react-testing-library and cover `ChooseJobProfile` component and util methods with tests. UIDEXP-179.
 
 ## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,4 @@ buildNPM {
   runLint = 'yes'
   runSonarqube = true
   runTest = 'yes'
-  runTestOptions = '--bundle --karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const esModules = ['@folio', 'ky'].join('|');
+
+module.exports = {
+  collectCoverageFrom: [
+    '**/(lib|src)/**/*.{js,jsx}',
+    '!**/node_modules/**',
+    '!**/test/**',
+  ],
+  coverageDirectory: './artifacts/coverage-jest/',
+  coverageReporters: ['lcov'],
+  reporters: ['jest-junit', 'default'],
+  transform: { '^.+\\.(js|jsx)$': path.join(__dirname, './test/jest/jest-transformer.js') },
+  transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
+  moduleNameMapper: {
+    '^.+\\.(css)$': 'identity-obj-proxy',
+    '^.+\\.(svg)$': 'identity-obj-proxy',
+  },
+  testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx}'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  setupFilesAfterEnv: [path.join(__dirname, './test/jest/jest.setup.js')],
+};

--- a/package.json
+++ b/package.json
@@ -16,10 +16,14 @@
     "build": "stripes build --output ./output",
     "lint": "eslint .",
     "lintfix": "eslint . --fix",
-    "test": "stripes test karma",
-    "test-coverage": "stripes test karma --coverage"
+    "test:jest": "jest --ci --coverage",
+    "test:bigtest": "stripes test karma",
+    "test:bigtest:coverage": "stripes test karma --coverage",
+    "test:bigtest:ci": "stripes test karma --bundle --karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage",
+    "test": "yarn run test:jest && yarn run test:bigtest:ci"
   },
   "devDependencies": {
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@bigtest/interactor": "^0.7.2",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
@@ -27,13 +31,22 @@
     "@folio/stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.18.0",
     "@folio/stripes-core": "^6.0.0",
+    "@testing-library/dom": "^7.26.3",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^10.4.7",
+    "@testing-library/user-event": "^12.1.10",
     "babel-eslint": "^9.0.0",
+    "babel-jest": "^26.1.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",
     "eslint": "^6.2.1",
     "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-jest": "^24.0.0",
     "faker": "^4.1.0",
     "inflected": "^2.0.4",
+    "jest": "^26.1.0",
+    "jest-css-modules": "^2.1.0",
+    "jest-junit": "^11.0.1",
     "miragejs": "^0.1.40",
     "mocha": "^5.2.0",
     "react": "^16.5.0",
@@ -56,12 +69,12 @@
   "peerDependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
     "@folio/stripes": "^5.0.0",
-    "react-virtualized-auto-sizer": "*",
+    "pretender": "*",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "*",
     "react-router-dom": "*",
-    "pretender": "*"
+    "react-virtualized-auto-sizer": "*"
   },
   "stripes": {
     "stripesDeps": [

--- a/src/components/ChooseJobProfile/ChooseJobProfile.js
+++ b/src/components/ChooseJobProfile/ChooseJobProfile.js
@@ -48,7 +48,7 @@ const ChooseJobProfileComponent = ({
       <JobProfiles
         parentResources={resources}
         parentMutator={mutator}
-        formatter={useListFormatter({ description: record => record.description || '' })}
+        formatter={useListFormatter({})}
         hasSearchForm={false}
         lastMenu={<div />}
         titleId="ui-data-export.jobProfiles.selectProfile.title"

--- a/src/components/ChooseJobProfile/ChooseJobProfilePage.test.js
+++ b/src/components/ChooseJobProfile/ChooseJobProfilePage.test.js
@@ -1,0 +1,182 @@
+import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import {
+  screen,
+  getByText,
+  getByRole,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '../../../test/jest/__mock__';
+
+import {
+  buildResources,
+  buildMutator,
+} from '@folio/stripes-data-transfer-components/testUtils';
+
+import { ChooseJobProfileComponent as ChooseJobProfile } from './ChooseJobProfile';
+import { translationsProperties } from '../../../test/helpers';
+import { renderWithIntl } from '../../../test/jest/helpers';
+
+const resources = buildResources({
+  resourceName: 'jobProfiles',
+  records: [{
+    id: 'jobProfile1',
+    name: 'A Lorem ipsum 1',
+    description: 'Description 1',
+    userInfo: {
+      firstName: 'Donald',
+      lastName: 'S',
+    },
+    metadata: { updatedDate: '2018-12-04T09:05:30.000+0000' },
+  },
+  {
+    id: 'jobProfile2',
+    name: 'A Lorem ipsum 2',
+    description: 'Description 2',
+    userInfo: {
+      firstName: 'Mark',
+      lastName: 'K',
+    },
+    metadata: { updatedDate: '2018-11-04T11:22:31.000+0000' },
+  }],
+  hasLoaded: true,
+});
+
+describe('ChooseJobProfile', () => {
+  describe('rendering ChooseJobProfile', () => {
+    const exportProfileSpy = jest.fn(Promise.resolve.bind(Promise));
+    const pushHistorySpy = jest.fn();
+    const mutator = buildMutator({ export: { POST: exportProfileSpy } });
+    const location = { state: { fileDefinitionId: 'fileDefinitionId' } };
+    let renderResult;
+
+    beforeEach(() => {
+      renderResult = renderWithIntl(
+        <Router>
+          <ChooseJobProfile
+            resources={resources}
+            mutator={mutator}
+            history={{ push: pushHistorySpy }}
+            location={location}
+          />
+        </Router>,
+        translationsProperties,
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should be visible', () => {
+      const { container } = renderResult;
+
+      expect(container.querySelector('#pane-results')).toBeVisible();
+    });
+
+    it('should display correct title and subtitle', () => {
+      const { container } = renderResult;
+      const paneHeader = container.querySelector('[data-test-pane-header]');
+
+      expect(getByText(paneHeader, 'Select job profile to run the export')).toBeVisible();
+      expect(getByText(paneHeader, '2 job profiles')).toBeVisible();
+    });
+
+    it('should place headers in correct order', () => {
+      const { container } = renderResult;
+      const headers = container.querySelectorAll('#search-results-list .mclHeader');
+
+      expect(getByText(headers[0], 'Name')).toBeVisible();
+      expect(getByText(headers[1], 'Description')).toBeVisible();
+      expect(getByText(headers[2], 'Updated')).toBeVisible();
+      expect(getByText(headers[3], 'Updated by')).toBeVisible();
+    });
+
+    it('should not display the confirmation modal', () => {
+      const { container } = renderResult;
+      const modal = container.querySelector('#choose-job-profile-confirmation-modal');
+
+      expect(modal).not.toBeInTheDocument();
+    });
+
+    it('should display correct data for the first row', () => {
+      const { container } = renderResult;
+      const row = container.querySelector('.mclRow');
+      const cells = row.querySelectorAll('.mclCell');
+
+      expect(getByText(cells[0], 'A Lorem ipsum 1')).toBeVisible();
+      expect(getByText(cells[1], 'Description 1')).toBeVisible();
+      expect(getByText(cells[2], '12/4/2018')).toBeVisible();
+      expect(getByText(cells[3], 'Donald S')).toBeVisible();
+    });
+
+    describe('clicking on row', () => {
+      beforeEach(() => {
+        const { container } = renderResult;
+        const row = container.querySelector('.mclRow');
+
+        userEvent.click(row);
+      });
+
+      it('should display modal with proper header', () => {
+        expect(screen.getByText('Are you sure you want to run this job?')).toBeInTheDocument();
+      });
+
+      it('should display modal profile name in the body', () => {
+        const bodyString = document.querySelector('[data-test-confirmation-modal-message]');
+
+        expect(bodyString.innerHTML).toEqual('You have selected <b>A Lorem ipsum 1</b> to run the export');
+      });
+
+      it('should display modal with proper wording for buttons', () => {
+        const modal = document.querySelector('#choose-job-profile-confirmation-modal');
+
+        expect(getByRole(modal, 'button', { name: 'Run' })).toBeVisible();
+        expect(getByRole(modal, 'button', { name: 'Cancel' })).toBeVisible();
+      });
+
+      it('clicking on cancel button should close the modal', () => {
+        const modal = document.querySelector('#choose-job-profile-confirmation-modal');
+
+        userEvent.click(getByRole(modal, 'button', { name: 'Cancel' }));
+
+        return waitForElementToBeRemoved(() => document.querySelector('#choose-job-profile-confirmation-modal'));
+      });
+
+      describe('clicking on confirm button - success case', () => {
+        beforeEach(() => {
+          const modal = document.querySelector('#choose-job-profile-confirmation-modal');
+
+          userEvent.click(getByRole(modal, 'button', { name: 'Run' }));
+        });
+
+        it('should initiate the export process by calling the API with correct params', () => {
+          expect(exportProfileSpy).toHaveBeenCalledWith({
+            fileDefinitionId: location.state.fileDefinitionId,
+            jobProfileId: resources.jobProfiles.records[0].id,
+          });
+        });
+
+        it('should navigate to the landing page', () => {
+          expect(pushHistorySpy).toHaveBeenCalledWith('/data-export');
+        });
+      });
+
+      describe('clicking on confirm button - error case', () => {
+        beforeEach(async () => {
+          const modal = document.querySelector('#choose-job-profile-confirmation-modal');
+
+          exportProfileSpy.mockImplementationOnce(Promise.reject.bind(Promise));
+          userEvent.click(getByRole(modal, 'button', { name: 'Run' }));
+          await waitForElementToBeRemoved(() => document.querySelector('#choose-job-profile-confirmation-modal'));
+        });
+
+        it('should not navigate to the landing page', () => {
+          expect(pushHistorySpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+});

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
@@ -1,0 +1,63 @@
+import { generateAffectedRecordInfo } from './generateAffectedRecordInfo';
+import { errorLogs } from '../../../../test/bigtest/fixtures/errorLogs';
+
+describe('generateAffectedRecordInfo', () => {
+  it('should return correct record info with no nesting', () => {
+    const logs = {
+      id: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+      hrid: 'inst000000000022',
+      title: 'A semantic web primer',
+      recordType: 'INSTANCE',
+      affectedRecords: [],
+    };
+
+    expect(generateAffectedRecordInfo(logs)).toEqual([
+      '{',
+      '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
+      '"Instance HRID": "inst000000000022"',
+      '"Instance Title": "A semantic web primer"',
+      '}',
+    ]);
+  });
+
+  it('should return correct record info with 1 level nesting', () => {
+    const logs = {
+      id: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+      hrid: 'inst000000000022',
+      title: 'A semantic web primer',
+      recordType: 'INSTANCE',
+      affectedRecords: [{
+        id: 'e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19',
+        hrid: 'hold000000000009',
+        recordType: 'HOLDINGS',
+        affectedRecords: [],
+      }],
+    };
+
+    expect(generateAffectedRecordInfo(logs)).toEqual([
+      '{',
+      '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
+      '"Instance HRID": "inst000000000022"',
+      '"Instance Title": "A semantic web primer"',
+      '"Associated Holdings UUID": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"',
+      '"Associated Holdings HRID": "hold000000000009"',
+      '}',
+    ]);
+  });
+
+  it('should return correct record info with 2 level nesting', () => {
+    expect(generateAffectedRecordInfo(errorLogs[2].affectedRecord)).toEqual([
+      '{',
+      '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
+      '"Instance HRID": "inst000000000022"',
+      '"Instance Title": "A semantic web primer"',
+      '"Associated Holdings UUID": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"',
+      '"Associated Holdings HRID": "hold000000000009"',
+      '"Associated Item UUID": "100d10bf-2f06-4aa0-be15-0b95b2d9f9e3"',
+      '"Associated Item HRID": "item000000000015"',
+      '"Associated Item UUID": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"',
+      '"Associated Item HRID": "item000000000014"',
+      '}',
+    ]);
+  });
+});

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -61,7 +61,7 @@ export const JobLogsContainer = props => {
       const fileName = get(record.exportedFiles, '0.fileName');
       const downloadLink = await getFileDownloadLink(record, okapi);
 
-      await downloadFileByLink(fileName, downloadLink);
+      downloadFileByLink(fileName, downloadLink);
     } catch (error) {
       handleDownloadError();
 

--- a/src/components/Jobs/RunningJobs/RunningJobs.js
+++ b/src/components/Jobs/RunningJobs/RunningJobs.js
@@ -15,13 +15,15 @@ const RunningJobs = () => {
   } = useContext(DataFetcherContext);
 
   return (
-    <JobsListAccordion
-      jobs={sortRunningJobs(jobs)}
-      hasLoaded={hasLoaded}
-      itemFormatter={ItemFormatter}
-      titleId="ui-data-export.runningJobs"
-      emptyMessageId="ui-data-export.noRunningJobsMessage"
-    />
+    <div data-test-running-jobs>
+      <JobsListAccordion
+        jobs={sortRunningJobs(jobs)}
+        hasLoaded={hasLoaded}
+        itemFormatter={ItemFormatter}
+        titleId="ui-data-export.runningJobs"
+        emptyMessageId="ui-data-export.noRunningJobsMessage"
+      />
+    </div>
   );
 };
 

--- a/src/components/QueryFileUploader/utils/generateFileDefinitionBody.test.js
+++ b/src/components/QueryFileUploader/utils/generateFileDefinitionBody.test.js
@@ -1,0 +1,19 @@
+import '../../../../test/jest/__mock__';
+import { generateFileDefinitionBody } from './generateFileDefinitionBody';
+
+describe('generateFileDefinitionBody', () => {
+  it('should create correct file definition body', () => {
+    const file = {
+      size: 1024,
+      name: 'File name',
+    };
+    const fileType = 'cql';
+    const okapiHeaders = generateFileDefinitionBody(file, fileType);
+
+    expect(okapiHeaders).toEqual({
+      fileName: file.name,
+      size: 1,
+      uploadFormat: fileType,
+    });
+  });
+});

--- a/src/components/QueryFileUploader/utils/getFileInfo.js
+++ b/src/components/QueryFileUploader/utils/getFileInfo.js
@@ -1,5 +1,5 @@
 import { getFileExtension } from '@folio/stripes-data-transfer-components';
-import { SUPPORTED_FILE_EXTENSIONS } from '../../../utils/constants';
+import { SUPPORTED_FILE_EXTENSIONS } from '../../../utils';
 
 export const getFileInfo = file => {
   const fileType = getFileExtension(file).slice(1);

--- a/src/components/QueryFileUploader/utils/getFileInfo.test.js
+++ b/src/components/QueryFileUploader/utils/getFileInfo.test.js
@@ -1,0 +1,31 @@
+import '../../../../test/jest/__mock__';
+import { getFileInfo } from './getFileInfo';
+
+describe('getFileInfo', () => {
+  it('should return correct data with supported cvs file type', () => {
+    const testFile = new File([], 'test.csv');
+
+    expect(getFileInfo(testFile)).toEqual({
+      isTypeSupported: true,
+      fileType: 'csv',
+    });
+  });
+
+  it('should return correct data with supported cql file type', () => {
+    const testFile = new File([], 'test.cql');
+
+    expect(getFileInfo(testFile)).toEqual({
+      isTypeSupported: true,
+      fileType: 'cql',
+    });
+  });
+
+  it('should return correct data with unsupported file type', () => {
+    const testFile = new File([], 'test.txt');
+
+    expect(getFileInfo(testFile)).toEqual({
+      isTypeSupported: false,
+      fileType: 'txt',
+    });
+  });
+});

--- a/src/utils/buildShouldRefresHandler.test.js
+++ b/src/utils/buildShouldRefresHandler.test.js
@@ -1,0 +1,35 @@
+import { buildShouldRefreshHandler } from './buildShouldRefreshHandler';
+
+describe('buildShouldRefreshHandler', () => {
+  const resourcesActionsToPrevent = { customResource: ['DELETE', 'POST'] };
+
+  it('should allow refresh if resourcesActionsToPrevent doesn\'t cover action', () => {
+    const actionWithDifferentName = {
+      meta: {
+        name: 'someResource',
+        originatingActionType: 'POST_RESOURCE',
+      },
+    };
+
+    const actionWithDifferentActionType = {
+      meta: {
+        name: 'customResource',
+        originatingActionType: 'PUT_RESOURCE',
+      },
+    };
+
+    expect(buildShouldRefreshHandler(resourcesActionsToPrevent)(null, actionWithDifferentName)).toBe(true);
+    expect(buildShouldRefreshHandler(resourcesActionsToPrevent)(null, actionWithDifferentActionType)).toBe(true);
+  });
+
+  it('should disallow refresh if resourcesActionsToPrevent covers action', () => {
+    const action = {
+      meta: {
+        name: 'customResource',
+        originatingActionType: 'POST_RESOURCE',
+      },
+    };
+
+    expect(buildShouldRefreshHandler(resourcesActionsToPrevent)(null, action)).toBe(false);
+  });
+});

--- a/src/utils/isTestEnv.js
+++ b/src/utils/isTestEnv.js
@@ -1,6 +1,1 @@
-/**
- * Finds out if execution context is in test environment or not
- *
- * @return {boolean}
- */
 export const isTestEnv = () => process.env.NODE_ENV === 'test';

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -1,0 +1,19 @@
+import {
+  required,
+  requiredArray,
+} from './validation';
+
+describe('generateFileDefinitionBody', () => {
+  it('should validate correct simple values', () => {
+    expect(required(10)).toBeUndefined();
+    expect(required(false)).toBeUndefined();
+    expect(required(0)).toBeUndefined();
+    expect(required(null)).not.toBeUndefined();
+  });
+
+  it('should validate correct array values', () => {
+    expect(requiredArray(null)).not.toBeUndefined();
+    expect(requiredArray([])).not.toBeUndefined();
+    expect(requiredArray([1])).toBeUndefined();
+  });
+});

--- a/test/bigtest/helpers/index.js
+++ b/test/bigtest/helpers/index.js
@@ -2,5 +2,4 @@ export * from './setupApplication';
 export * from './prefixKeys';
 export * from './getTotalSelectedMessage';
 export * from './OverlayContainer';
-export * from './translationsProperties';
 export * from './getColumnIndexMapping';

--- a/test/bigtest/tests/settings-test.js
+++ b/test/bigtest/tests/settings-test.js
@@ -34,7 +34,7 @@ describe('Settings', () => {
   });
 
   it('should not display profiles inform popover', () => {
-    expect(settingsSectionsPane.profilesPopover.isPresent).to.be.false;
+    expect(settingsSectionsPane.profilesPopover.content.isPresent).to.be.false;
   });
 
   it('should display section labels', () => {
@@ -79,11 +79,7 @@ describe('Settings', () => {
       await wait();
     });
 
-    it('should display profiles inform popover', () => {
-      expect(settingsSectionsPane.profilesPopover.isPresent).to.be.true;
-    });
-
-    it('should display correct message in inform popover', () => {
+    it('should not display profiles inform popover with correct message', () => {
       expect(settingsSectionsPane.profilesPopover.content.text).to.equal(translations['settings.profilesInfo']);
     });
 

--- a/test/bigtest/tests/units/AllJobLogs-test.js
+++ b/test/bigtest/tests/units/AllJobLogs-test.js
@@ -27,9 +27,9 @@ import { allLogsPaneInteractor } from '../../interactors';
 import { AllJobLogsViewComponent } from '../../../../src/components/AllJobLogsView';
 import {
   OverlayContainer,
-  translationsProperties,
   getColumnIndexMapping,
 } from '../../helpers';
+import { translationsProperties } from '../../../helpers';
 import { logJobExecutions } from '../../network/scenarios/fetch-job-executions-success';
 import { DEFAULT_JOB_LOG_COLUMNS } from '../../../../src/utils';
 

--- a/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
+++ b/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
@@ -16,7 +16,7 @@ import {
 } from '@folio/stripes-data-transfer-components/interactors';
 
 import { ErrorLogsViewComponent } from '../../../../../src/components/ErrorLogsView';
-import { translationsProperties } from '../../../helpers';
+import { translationsProperties } from '../../../../helpers';
 import { errorLogs } from '../../../fixtures/errorLogs';
 import { errorLogsInteractor } from './interactor';
 

--- a/test/bigtest/tests/units/settings/ChooseJobProfilePage/ChooseJobProfilePage-test.js
+++ b/test/bigtest/tests/units/settings/ChooseJobProfilePage/ChooseJobProfilePage-test.js
@@ -18,7 +18,7 @@ import {
 import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 
 import translations from '../../../../../../translations/ui-data-export/en';
-import { translationsProperties } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { ChooseJobProfileComponent as ChooseJobProfile } from '../../../../../../src/components/ChooseJobProfile';
 import { ChooseJobProfileInteractor } from './interactor';
 

--- a/test/bigtest/tests/units/settings/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute-test.js
@@ -27,10 +27,10 @@ import {
   generateTransformationsWithDisplayName,
 } from '../../../../network/scenarios/fetch-mapping-profiles-success';
 import {
-  translationsProperties,
   OverlayContainer,
   getTotalSelectedMessage,
 } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { DuplicateMappingProfileRouteComponent } from '../../../../../../src/settings/MappingProfiles/DuplicateMappingProfileRoute';
 import { DuplicateMappingProfileRouteInteractor } from './interactors/DuplicateMappingProfileRouteInteractor';
 import translations from '../../../../../../translations/ui-data-export/en';

--- a/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
@@ -27,10 +27,10 @@ import {
   generateTransformationsWithDisplayName,
 } from '../../../../network/scenarios/fetch-mapping-profiles-success';
 import {
-  translationsProperties,
   OverlayContainer,
   getTotalSelectedMessage,
 } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { EditMappingProfileRouteComponent } from '../../../../../../src/settings/MappingProfiles/EditMappingProfileRoute';
 import { EditMappingProfileRouteInteractor } from './interactors/EditMappingProfileRouteInteractor';
 import translations from '../../../../../../translations/ui-data-export/en';

--- a/test/bigtest/tests/units/settings/JobProfilesForm/JobProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/JobProfilesForm/JobProfilesForm-test.js
@@ -16,7 +16,7 @@ import { mountWithContext } from '@folio/stripes-data-transfer-components/intera
 import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 
 import translations from '../../../../../../translations/ui-data-export/en';
-import { translationsProperties } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { JobProfilesForm } from '../../../../../../src/settings/JobProfiles/JobProfilesForm';
 import { JobProfilesFormInteractor } from './interactor';
 

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
@@ -18,7 +18,7 @@ import {
 import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 
 import translations from '../../../../../../translations/ui-data-export/en';
-import { translationsProperties } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { JobProfileDetails } from '../../../../../../src/settings/JobProfiles/JobProfileDetails';
 import { JobProfileDetailsInteractor } from './interactors/JobProfileDetailsInteractor';
 import { mappingProfile } from '../../../../network/scenarios/fetch-mapping-profiles-success';

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
@@ -13,7 +13,7 @@ import { noop } from 'lodash';
 import { Paneset } from '@folio/stripes/components';
 import { mountWithContext } from '@folio/stripes-data-transfer-components/interactors';
 
-import { translationsProperties } from '../../../../helpers/translationsProperties';
+import { translationsProperties } from '../../../../../helpers';
 import { JobProfileDetailsRoute } from '../../../../../../src/settings/JobProfiles/JobProfileDetailsRoute';
 import { JobProfileDetailsInteractor } from './interactors/JobProfileDetailsInteractor';
 import { mappingProfile } from '../../../../network/scenarios/fetch-mapping-profiles-success';

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
@@ -19,7 +19,7 @@ import {
 import commonTranslations from '@folio/stripes-data-transfer-components/translations/stripes-data-transfer-components/en';
 
 import translations from '../../../../../../translations/ui-data-export/en';
-import { translationsProperties } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { MappingProfileDetails } from '../../../../../../src/settings/MappingProfiles/MappingProfileDetails';
 import { MappingProfileDetailsInteractor } from './interactors/MappingProfileDetailsInteractor';
 import {

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -22,10 +22,10 @@ import commonTranslations from '@folio/stripes-data-transfer-components/translat
 
 import translations from '../../../../../../translations/ui-data-export/en';
 import {
-  translationsProperties,
   OverlayContainer,
   getTotalSelectedMessage,
 } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { MappingProfilesFormInteractor } from './interactors/MappingProfilesFormInteractor';
 import { MappingProfilesFormContainer } from '../../../../../../src/settings/MappingProfiles/MappingProfilesFormContainer';
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
@@ -16,10 +16,10 @@ import commonTranslations from '@folio/stripes-data-transfer-components/translat
 
 import { MappingProfilesTransformationsModal } from '../../../../../../src/settings/MappingProfiles/MappingProfilesTransformationsModal';
 import {
-  translationsProperties,
   getTotalSelectedMessage,
   OverlayContainer,
 } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import { TransformationsModalInteractor } from './interactors/TransformationsModalInteractor';
 import translations from '../../../../../../translations/ui-data-export/en';
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsSearchForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsSearchForm-test.js
@@ -18,7 +18,7 @@ import {
   SELECTED_STATUSES,
 } from '../../../../../../src/utils';
 import { SearchForm } from '../../../../../../src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm';
-import { translationsProperties } from '../../../../helpers';
+import { translationsProperties } from '../../../../../helpers';
 import translations from '../../../../../../translations/ui-data-export/en';
 import { TransformationsSearchFormInteractor } from './interactors/TransformationsSearchFormInteractor';
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,1 @@
+export * from './translationsProperties';

--- a/test/helpers/translationsProperties.js
+++ b/test/helpers/translationsProperties.js
@@ -1,6 +1,6 @@
 import stripesComponentsTranslations from '@folio/stripes-components/translations/stripes-components/en';
 
-import translations from '../../../translations/ui-data-export/en';
+import translations from '../../translations/ui-data-export/en';
 
 export const translationsProperties = [
   {

--- a/test/jest/__mock__/currencyData.mock.js
+++ b/test/jest/__mock__/currencyData.mock.js
@@ -1,0 +1,1 @@
+jest.mock('currency-codes/data', () => ({ filter: () => [] }));

--- a/test/jest/__mock__/documentCreateRange.mock.js
+++ b/test/jest/__mock__/documentCreateRange.mock.js
@@ -1,0 +1,8 @@
+global.document.createRange = () => ({
+  setStart: () => {},
+  setEnd: () => {},
+  commonAncestorContainer: {
+    nodeName: 'BODY',
+    ownerDocument: document,
+  },
+});

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -1,0 +1,7 @@
+import './currencyData.mock';
+import './documentCreateRange.mock';
+import './matchMedia.mock';
+import './stripesConfig.mock';
+import './stripesCore.mock';
+import './stripesIcon.mock';
+import './stripesSmartComponents.mock';

--- a/test/jest/__mock__/matchMedia.mock.js
+++ b/test/jest/__mock__/matchMedia.mock.js
@@ -1,0 +1,12 @@
+window.matchMedia = jest.fn().mockImplementation(query => {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  };
+});

--- a/test/jest/__mock__/stripesConfig.mock.js
+++ b/test/jest/__mock__/stripesConfig.mock.js
@@ -1,0 +1,1 @@
+jest.mock('stripes-config', () => ({ modules: [] }), { virtual: true });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  stripesConnect: Component => props => <Component {...props} />,
+}), { virtual: true });

--- a/test/jest/__mock__/stripesIcon.mock.js
+++ b/test/jest/__mock__/stripesIcon.mock.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+jest.mock('@folio/stripes-components/lib/Icon', () => {
+  return () => <span>Icon</span>;
+});

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+jest.mock('@folio/stripes/smart-components', () => ({
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  LocationLookup: () => <div>LocationLookup</div>,
+}), { virtual: true });

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  presets: [
+    '@babel/preset-env',
+    '@babel/preset-react',
+  ],
+  plugins: [
+    [
+      '@babel/plugin-proposal-decorators',
+      { legacy: true },
+    ],
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-transform-runtime',
+  ],
+};

--- a/test/jest/helpers/index.js
+++ b/test/jest/helpers/index.js
@@ -1,0 +1,1 @@
+export * from './renderWithIntl';

--- a/test/jest/helpers/renderWithIntl.js
+++ b/test/jest/helpers/renderWithIntl.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { Harness } from '@folio/stripes-data-transfer-components/testUtils';
+
+export const renderWithIntl = (children, translations = []) => render(
+  <Harness translations={translations}>
+    {children}
+  </Harness>,
+);

--- a/test/jest/jest-transformer.js
+++ b/test/jest/jest-transformer.js
@@ -1,0 +1,5 @@
+const babelJest = require('babel-jest');
+
+const babelConf = require('./babel.config');
+
+module.exports = babelJest.createTransformer(babelConf);

--- a/test/jest/jest.setup.js
+++ b/test/jest/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Purpose
* Setup jest/react-testing-library and cover `ChooseJobProfile` component and util methods with tests. UIDEXP-179.
* Adjust `ui-data-export` after the change in the `JobsListAccordion` in `stripes-data-transfer-components` with regard to data-test attribute. UIDATIMP-574.

## Screenshots

Coverage
<img width="977" alt="Screen Shot 2020-10-28 at 2 05 03 PM" src="https://user-images.githubusercontent.com/40821852/97445005-7281c380-1935-11eb-90c2-2ca1d3d792a6.png">
<img width="977" alt="Screen Shot 2020-10-28 at 2 05 41 PM" src="https://user-images.githubusercontent.com/40821852/97445014-74e41d80-1935-11eb-8066-07eddc2ed701.png">
<img width="977" alt="Screen Shot 2020-10-28 at 2 04 50 PM" src="https://user-images.githubusercontent.com/40821852/97445021-76154a80-1935-11eb-992f-4cda3d334b62.png">
<img width="977" alt="Screen Shot 2020-10-28 at 2 04 35 PM" src="https://user-images.githubusercontent.com/40821852/97445026-76154a80-1935-11eb-9bf1-dda14ad682f6.png">
