### PR TITLE
UIDATIMP-580: Bump babel-eslint to v10.0.3, adjust test after updates to Preloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Setup jest/react-testing-library and cover `ChooseJobProfile` component and util methods with tests. UIDEXP-179.
 * Adjust `ui-data-export` after the change in the `JobsListAccordion` in `stripes-data-transfer-components` with regard to data-test attribute. UIDATIMP-574.
 * Add "Copy of" to the mapping profile name upon duplication. UIDEXP-181.
+* Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor. UIDATIMP-580.
 
 ## [3.0.0](https://github.com/folio-org/ui-data-export/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v2.0.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^10.4.7",
     "@testing-library/user-event": "^12.1.10",
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^10.0.3",
     "babel-jest": "^26.1.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",

--- a/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
+++ b/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
@@ -77,7 +77,7 @@ describe('ErrorLogsView', () => {
     });
 
     it('should display preloader', () => {
-      expect(preloader.isSpinnerPresent).to.be.true;
+      expect(preloader.spinner.isPresent).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
@@ -207,7 +207,7 @@ describe('JobProfileDetails', () => {
     });
 
     it('should display preloader', () => {
-      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+      expect(jobProfileDetails.preloader.spinner.isPresent).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
@@ -60,7 +60,7 @@ describe('JobProfileDetails', () => {
     });
 
     it('should display preloader', () => {
-      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+      expect(jobProfileDetails.preloader.spinner.isPresent).to.be.true;
     });
   });
 
@@ -77,7 +77,7 @@ describe('JobProfileDetails', () => {
     });
 
     it('should display preloader', () => {
-      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+      expect(jobProfileDetails.preloader.spinner.isPresent).to.be.true;
     });
   });
 
@@ -101,7 +101,7 @@ describe('JobProfileDetails', () => {
     });
 
     it('should display preloader', () => {
-      expect(jobProfileDetails.preloader.isSpinnerPresent).to.be.true;
+      expect(jobProfileDetails.preloader.spinner.isPresent).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
@@ -243,7 +243,7 @@ describe('MappingProfileDetails', () => {
     });
 
     it('should display preloader', () => {
-      expect(mappingProfileDetails.preloader.isSpinnerPresent).to.be.true;
+      expect(mappingProfileDetails.preloader.spinner.isPresent).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Purpose

Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor.