### PR TITLE
UIDEXP-206: Fix ESLint inconsistency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -78,7 +78,13 @@
     "no-void": "off",
     "comma-dangle": [
       "error",
-      "always-multiline"
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+      }
     ],
     "arrow-parens": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add "Copy of" to the mapping profile name upon duplication. UIDEXP-181.
 * Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor. UIDATIMP-580.
 * Add Source Record Storage option to the mapping profile. UIDEPX-178.
+* Handle `ESLint` inconsistencies with `stripes-data-transfer-components` module. UIDEXP-206.
 
 ## [3.0.1](https://github.com/folio-org/ui-data-export/tree/v3.0.1) (2020-11-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.0...v3.0.1)

--- a/src/common/jobProfilesManifest.js
+++ b/src/common/jobProfilesManifest.js
@@ -30,7 +30,7 @@ export const jobProfilesManifest = {
           FIND_ALL_CQL,
           QUERY_TEMPLATE,
           sortMap,
-          [],
+          []
         ),
       },
       staticFallback: { params: {} },

--- a/src/components/AllJobLogsView/AllJobLogsView.js
+++ b/src/components/AllJobLogsView/AllJobLogsView.js
@@ -88,7 +88,7 @@ AllJobLogsViewComponent.manifest = Object.freeze({
           findAllCql,
           findAllCql,
           sortMap,
-          [],
+          []
         ),
       },
       staticFallback: { params: {} },

--- a/src/components/ChooseJobProfile/ChooseJobProfilePage.test.js
+++ b/src/components/ChooseJobProfile/ChooseJobProfilePage.test.js
@@ -62,7 +62,7 @@ describe('ChooseJobProfile', () => {
             location={location}
           />
         </Router>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -121,7 +121,7 @@ export const JobLogsContainer = props => {
 
           return failed || '';
         },
-      },
+      }
     ),
   };
 

--- a/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
+++ b/src/settings/JobProfiles/JobProfilesContainer/JobProfilesContainer.js
@@ -39,7 +39,7 @@ const JobProfilesContainer = ({
 }) => {
   const JobProfileDetailsRouteConnected = useMemo(
     () => stripes.connect(JobProfileDetailsRoute, { dataKey: 'job-profile-details' }),
-    [stripes],
+    [stripes]
   );
 
   return (

--- a/src/settings/MappingProfiles/CreateMappingProfileFormRoute/CreateMappingProfileFormRoute.test.js
+++ b/src/settings/MappingProfiles/CreateMappingProfileFormRoute/CreateMappingProfileFormRoute.test.js
@@ -63,7 +63,7 @@ describe('CreateMappingProfileFormRoute', () => {
           onSubmitNavigate={onSubmitNavigateMock}
           onSubmit={onSubmitMock}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -111,7 +111,7 @@ describe('CreateMappingProfileFormRoute', () => {
 
       await waitFor(() => {
         expect(sendCalloutMock).toBeCalledWith(
-          expect.objectContaining({ type: 'error' }),
+          expect.objectContaining({ type: 'error' })
         );
         expect(sendCalloutMock.mock.calls[0][0].message.props.id).toBe('ui-data-export.mappingProfiles.create.errorCallout');
       });

--- a/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.js
+++ b/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.js
@@ -33,7 +33,7 @@ export const DuplicateMappingProfileRouteComponent = ({
     ...mappingProfileRecord,
     name: intl.formatMessage(
       { id: 'ui-data-export.copyOf' },
-      { value: mappingProfileRecord.name },
+      { value: mappingProfileRecord.name }
     ),
   };
 

--- a/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
+++ b/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
@@ -63,7 +63,7 @@ describe('DuplicateMappingProfileRoute', () => {
     beforeEach(() => {
       renderWithIntl(
         <DuplicateMappingProfileRouteContainer allTransformations={allMappingProfilesTransformations} />,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesContainer/MappingProfilesContainer.js
@@ -75,16 +75,16 @@ const MappingProfilesContainer = ({
         ...transformation,
         displayName: intl.formatMessage(
           { id: `ui-data-export.${transformation.displayNameKey}` },
-          { value: transformation.referenceDataValue },
+          { value: transformation.referenceDataValue }
         ),
       })), 'displayName', 'asc'),
-    [intl, resources.transformations.records],
+    [intl, resources.transformations.records]
   );
   const isTransformationsLoaded = get(resources, 'transformations.hasLoaded', false);
 
   const handleNavigationToMappingProfilesList = useCallback(
     () => push(`${path}${search}`),
-    [push, path, search],
+    [push, path, search]
   );
 
   const buildMappingProfileViewNavigationHandler = useCallback(
@@ -92,7 +92,7 @@ const MappingProfilesContainer = ({
       match,
       location,
     }) => () => push(`/settings/data-export/mapping-profiles/view/${match.params.id}${location.search}`),
-    [push],
+    [push]
   );
 
   return (
@@ -207,7 +207,7 @@ MappingProfilesContainer.manifest = Object.freeze({
           FIND_ALL_CQL,
           queryTemplate,
           sortMap,
-          [],
+          []
         ),
       },
       staticFallback: { params: {} },

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -53,8 +53,8 @@ export const MappingProfilesFormContainer = props => {
     () => generateSelectedTransformations(
       selectedTransformations,
       selectedTransformation => modalTransformations.transformations
-        .find(transformation => selectedTransformation.fieldId === transformation.fieldId),
-    ),
+        .find(transformation => selectedTransformation.fieldId === transformation.fieldId)
+    )
   );
   const [disabledRecordTypes, setDisabledRecordTypes] = useState({
     [FOLIO_RECORD_TYPES.SRS.type]: false,

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -55,7 +55,7 @@ describe('MappingProfileFormContainer', () => {
         <MappingProfileFormContainer
           allTransformations={allMappingProfilesTransformations}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -120,7 +120,7 @@ export const MappingProfilesTransformationsModal = ({
 
   const handleSelectChange = useCallback(
     transformations => setSelectedTransformations(transformations),
-    [],
+    []
   );
 
   const handleSearchFormSubmit = useCallback(values => {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/SearchForm/SearchForm.js
@@ -42,12 +42,12 @@ const SearchFormComponent = ({
 
   const handleRecordTypesFilterChange = useCallback(
     (event, option) => updateFilter('recordTypes', event.target.checked, option),
-    [updateFilter],
+    [updateFilter]
   );
 
   const handleStatusesFilterChange = useCallback(
     (event, option) => updateFilter('statuses', event.target.checked, option),
-    [updateFilter],
+    [updateFilter]
   );
 
   const handleReset = useCallback(() => {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
@@ -32,7 +32,7 @@ const TransformationsFormComponent = memo(({
     const transformations = get(getFormState(), 'values.transformations', []);
     const selectedTransformations = generateSelectedTransformations(
       transformations,
-      transformation => transformation.isSelected && transformation,
+      transformation => transformation.isSelected && transformation
     );
 
     onSelectChange(selectedTransformations);

--- a/test/bigtest/network/scenarios/fetch-mapping-profiles-success.js
+++ b/test/bigtest/network/scenarios/fetch-mapping-profiles-success.js
@@ -20,7 +20,7 @@ export const generateTransformationsWithDisplayName = (intl, transformations) =>
   ...transformation,
   displayName: intl.formatMessage(
     { id: `ui-data-export.${transformation.displayNameKey}` },
-    { value: transformation.referenceDataValue },
+    { value: transformation.referenceDataValue }
   ),
 }));
 

--- a/test/bigtest/tests/units/AllJobLogs-test.js
+++ b/test/bigtest/tests/units/AllJobLogs-test.js
@@ -75,7 +75,7 @@ describe('AllJobLogsView', () => {
           <OverlayContainer />
         </Router>
       </StripesContext.Provider>,
-      translationsProperties,
+      translationsProperties
     );
   });
 

--- a/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
+++ b/test/bigtest/tests/units/ErrorLogs/ErrorLogs-test.js
@@ -35,7 +35,7 @@ describe('ErrorLogsView', () => {
           })}
           mutator={buildMutator()}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -72,7 +72,7 @@ describe('ErrorLogsView', () => {
           })}
           mutator={buildMutator()}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -94,8 +94,8 @@ describe('ErrorLogsView manifest path function', () => {
         null,
         null,
         null,
-        { location: { pathname: `/data-export/log/${recordId}` } },
-      ),
+        { location: { pathname: `/data-export/log/${recordId}` } }
+      )
     ).to.equal(`data-export/logs?query=(jobExecutionId==${recordId})`);
   });
 });

--- a/test/bigtest/tests/units/settings/ChooseJobProfilePage/ChooseJobProfilePage-test.js
+++ b/test/bigtest/tests/units/settings/ChooseJobProfilePage/ChooseJobProfilePage-test.js
@@ -73,7 +73,7 @@ describe('ChooseJobProfile', () => {
             location={location}
           />
         </Router>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute-test.js
@@ -79,7 +79,7 @@ describe('DuplicateMappingProfileRoute', () => {
     beforeEach(async () => {
       await mountWithContext(
         <DuplicateMappingProfileRouteContainer profile={null} />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -108,7 +108,7 @@ describe('DuplicateMappingProfileRoute', () => {
           onCancel={handleCancelSpy}
           onSubmitNavigate={handleSubmitNavigateSpy}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
@@ -78,7 +78,7 @@ describe('EditMappingProfileRoute', () => {
     beforeEach(async () => {
       await mountWithContext(
         <EditMappingProfileRouteContainer profile={null} />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -107,7 +107,7 @@ describe('EditMappingProfileRoute', () => {
           onCancel={handleCancelSpy}
           onSubmitNavigate={handleSaveSpy}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -284,7 +284,7 @@ describe('EditMappingProfileRoute', () => {
             transformations: null,
           }}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/JobProfilesForm/JobProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/JobProfilesForm/JobProfilesForm-test.js
@@ -57,7 +57,7 @@ describe('JobProfilesForm', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -184,7 +184,7 @@ describe('JobProfilesForm', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -218,7 +218,7 @@ describe('JobProfilesForm', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetails-test.js
@@ -56,7 +56,7 @@ describe('JobProfileDetails', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -130,7 +130,7 @@ describe('JobProfileDetails', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -202,7 +202,7 @@ describe('JobProfileDetails', () => {
             />
           </Router>
         </Paneset>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
+++ b/test/bigtest/tests/units/settings/JopProfileDetails/JobProfileDetailsRoute-test.js
@@ -37,7 +37,7 @@ async function setupJobProfileDetailsRoute({
         />
       </Router>
     </Paneset>,
-    translationsProperties,
+    translationsProperties
   );
 }
 

--- a/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfileDetails/MappingProfileDetails-test.js
@@ -85,7 +85,7 @@ describe('MappingProfileDetails', () => {
           isProfileUsed
           allTransformations={allMappingProfilesTransformations}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -168,7 +168,7 @@ describe('MappingProfileDetails', () => {
     beforeEach(async () => {
       await mountWithContext(
         <MappingProfileDetailsContainer mappingProfile={mappingProfileWithoutTransformations} />,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -238,7 +238,7 @@ describe('MappingProfileDetails', () => {
           isProfileUsed
           mappingProfile={mappingProfileWithoutTransformations}
         />,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/MappingProfilesForm-test.js
@@ -81,7 +81,7 @@ describe('MappingProfilesForm', () => {
             </Router>
           </Paneset>
         </>,
-        translationsProperties,
+        translationsProperties
       );
     });
 
@@ -386,7 +386,7 @@ describe('MappingProfilesForm', () => {
             </Router>
           </Paneset>
         </>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsModal-test.js
@@ -82,7 +82,7 @@ describe('MappingProfilesTransformationsModal', () => {
             onCancel={handleCloseSpy}
           />
         </Router>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsSearchForm-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/TransformationsSearchForm-test.js
@@ -54,7 +54,7 @@ describe('TransformationsSearchForm', () => {
             onSubmit={handleSubmitSpy}
           />
         </Router>,
-        translationsProperties,
+        translationsProperties
       );
     });
 

--- a/test/bigtest/tests/units/settings/MappingProfilesForm/mappingProfilesTransformationsUtils-test.js
+++ b/test/bigtest/tests/units/settings/MappingProfilesForm/mappingProfilesTransformationsUtils-test.js
@@ -43,7 +43,7 @@ describe('generateTransformationFieldsValues', () => {
           displayNameKey: 'materialTypeId',
           order: 1,
         },
-      ],
+      ]
     );
   });
 
@@ -82,7 +82,7 @@ describe('generateTransformationFieldsValues', () => {
           isSelected: true,
           order: 1,
         },
-      ],
+      ]
     );
   });
 
@@ -107,7 +107,7 @@ describe('generateTransformationFieldsValues', () => {
           ...allTransformations[1],
           order: 1,
         },
-      ],
+      ]
     );
   });
 });
@@ -145,7 +145,7 @@ describe('normalizeTransformationFormValues', () => {
           transformation: 'Transformation value 1',
           enabled: true,
         },
-      ],
+      ]
     );
   });
 });

--- a/test/jest/helpers/renderWithIntl.js
+++ b/test/jest/helpers/renderWithIntl.js
@@ -6,5 +6,5 @@ import { Harness } from '@folio/stripes-data-transfer-components/testUtils';
 export const renderWithIntl = (children, translations = []) => render(
   <Harness translations={translations}>
     {children}
-  </Harness>,
+  </Harness>
 );


### PR DESCRIPTION
## Overview
In the scope of [UIDEXP-206](https://issues.folio.org/browse/UIDEXP-206).
Currently, `ui-data-export` and `stripes-data-trasnfer-components` have some `ESLint` rules differences.
This PR aligns `ui-data-export` rules with `stripes-data-trasnfer-components`.