### PR TITLE
UIDEXP-208: Handle missing job progress field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor. UIDATIMP-580.
 * Add Source Record Storage option to the mapping profile. UIDEPX-178.
 * Handle `ESLint` inconsistencies with `stripes-data-transfer-components` module. UIDEXP-206.
+* Handle missing job progress field. UIDEXP-208.
 
 ## [3.0.1](https://github.com/folio-org/ui-data-export/tree/v3.0.1) (2020-11-12)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.0...v3.0.1)

--- a/src/components/JobLogsContainer/JobLogsContainer.js
+++ b/src/components/JobLogsContainer/JobLogsContainer.js
@@ -72,7 +72,7 @@ export const JobLogsContainer = props => {
   const getFileNameField = record => {
     const fileName = get(record.exportedFiles, '0.fileName');
 
-    if (!record.progress.exported) {
+    if (!record.progress?.exported) {
       return (
         <span
           title={fileName}
@@ -117,7 +117,7 @@ export const JobLogsContainer = props => {
         status: record => intl.formatMessage({ id: `ui-data-export.jobStatus.${camelCase(record.status)}` }),
         fileName: record => getFileNameField(record),
         errors: record => {
-          const { progress: { failed } } = record;
+          const failed = record.progress?.failed;
 
           return failed || '';
         },


### PR DESCRIPTION
## Purpose
In the sope of [UIDEXP-208](https://issues.folio.org/browse/UIDEXP-208).
For some edge cases, the progress field for job log is not provided, which causes UI to break. This PR prevents UI from breaking.