### PR TITLE
UIDEXP-207: Update module version and changelog after bugfix v3.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor. UIDATIMP-580.
 * Add Source Record Storage option to the mapping profile. UIDEPX-178.
 * Handle `ESLint` inconsistencies with `stripes-data-transfer-components` module. UIDEXP-206.
+
+## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
+[Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)
 * Handle missing job progress field. UIDEXP-208.
 
 ## [3.0.1](https://github.com/folio-org/ui-data-export/tree/v3.0.1) (2020-11-12)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/data-export",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Data export manager",
   "main": "src/index.js",
   "repository": "folio-org/ui-data-export",


### PR DESCRIPTION
## Purpose 
Update module version and changelog after bugfix v3.0.1 release in the scope of the [UIDEXP-201](https://issues.folio.org/browse/UIDEXP-201).