### PR TITLE
UIDEXP-209: Fix inability to create mapping profile with SRS and Holdings/Item types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Bump `babel-eslint` to `v10.0.3`, adjust tests after updates to `Preloader` interactor. UIDATIMP-580.
 * Add Source Record Storage option to the mapping profile. UIDEPX-178.
 * Handle `ESLint` inconsistencies with `stripes-data-transfer-components` module. UIDEXP-206.
+* Fix inability to create mapping profile with SRS and Holdings/Item types. UIDEXP-209.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -33,8 +33,10 @@ const isValidRecordTypesMatching = (selectedTransformations = [], selectedRecord
 
   const recordTypesInTransformations = uniq(selectedTransformations.map(({ recordType }) => recordType));
 
-  return isEmpty(difference(recordTypesInTransformations, selectedRecordTypes))
-    && isEmpty(difference(selectedRecordTypes, recordTypesInTransformations));
+  const validatedRecords = selectedRecordTypes.filter(recordType => recordType !== FOLIO_RECORD_TYPES.SRS.type);
+
+  return isEmpty(difference(recordTypesInTransformations, validatedRecords))
+    && isEmpty(difference(validatedRecords, recordTypesInTransformations));
 };
 
 export const MappingProfilesFormContainer = props => {

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -8,7 +8,10 @@ import {
   getAllByRole,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { waitForElementToBeRemoved } from '@testing-library/dom';
+import {
+  queryByText,
+  waitForElementToBeRemoved,
+} from '@testing-library/dom';
 
 import '../../../../test/jest/__mock__';
 
@@ -50,10 +53,13 @@ const MappingProfileFormContainer = ({
 
 describe('MappingProfileFormContainer', () => {
   describe('rendering MappingProfileForm', () => {
+    const onSubmitMock = jest.fn();
+
     beforeEach(() => {
       renderWithIntl(
         <MappingProfileFormContainer
           allTransformations={allMappingProfilesTransformations}
+          onSubmit={onSubmitMock}
         />,
         translationsProperties
       );
@@ -184,6 +190,19 @@ describe('MappingProfileFormContainer', () => {
         userEvent.click(getByRole(modal, 'button', { name: 'Save & close' }));
 
         expect(formSubmitButton).toBeDisabled();
+      });
+
+      it('should not display validation for record types when SRS and holdings types are checked', () => {
+        const folioRecordTypeContainer = document.querySelector('[data-test-folio-record-type]');
+
+        userEvent.type(screen.getByLabelText('Name*'), 'Name');
+        userEvent.click(getByRole(folioRecordTypeContainer, 'checkbox', { name: 'Holdings' }));
+        userEvent.click(screen.getByRole('checkbox', { name: 'Source record storage (entire record)' }));
+        userEvent.click(getByRole(footer, 'button', { name: 'Save & close' }));
+
+        expect(queryByText(document.querySelector('[data-test-folio-record-type]'),
+          'Selected record types do not match specified transformations')).toBeNull();
+        expect(onSubmitMock).toBeCalled();
       });
 
       describe('reopening transformation modal', () => {


### PR DESCRIPTION
## Purpose 
In the scope of [UIDEXP-209](https://issues.folio.org/browse/UIDEXP-209).
When saving mapping profile with SRS and Holdings or/and Item record types, the form did not pass the validation. This PR fixes the issue.
