### PR TITLE
UIDEXP-186: Move pretender to dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix inability to create mapping profile with SRS and Holdings/Item types. UIDEXP-209.
 * Modify transformation form to ensure proper data entry for MARC Bib mappings. UIDEXP-180.
 * Migrate to local callout solution. UIDEXP-143.
+* Move pretender to dev dependencies. UIDEXP-186.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jest-junit": "^11.0.1",
     "miragejs": "^0.1.40",
     "mocha": "^5.2.0",
+    "pretender": "^3.4.3",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^5.7.0",
@@ -69,7 +70,6 @@
   "peerDependencies": {
     "@folio/react-intl-safe-html": "^2.0.0",
     "@folio/stripes": "^5.0.0",
-    "pretender": "*",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "*",


### PR DESCRIPTION
## Purpose

Move pretender to dev dependencies in the scope of the [UIDEXP-186](https://issues.folio.org/browse/UIDEXP-186).