### PR TITLE
UIDEXP-187: Add validation to the transformation elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Migrate to local callout solution. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
 * Change failed job row click behavior, so it redirects to a page within same tab. UIDEXP-200.
-* Add validation to the transformation elements. UIDEXP-187.
+* Add validation to the mapping profile transformations. UIDEXP-187.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Migrate to local callout solution. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
 * Change failed job row click behavior, so it redirects to a page within same tab. UIDEXP-200.
+* Add validation to the transformation elements. UIDEXP-187.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -52,12 +52,10 @@ export const MappingProfilesFormContainer = props => {
   const [selectedTransformations, setSelectedTransformations] = useState(initialValues.transformations);
   const [modalTransformations, setModalTransformations] = useState({ transformations: generateTransformationFieldsValues(allTransformations, initialValues.transformations) });
   const calloutRef = useRef(null);
-  const [initialSelectedTransformations] = useState(
-    () => generateSelectedTransformations(
-      selectedTransformations,
-      selectedTransformation => modalTransformations.transformations
-        .find(transformation => selectedTransformation.fieldId === transformation.fieldId)
-    )
+  const generateSelectedTransformationsPredicate = selectedTransformation => modalTransformations.transformations
+    .find(transformation => selectedTransformation.fieldId === transformation.fieldId);
+  const [initialSelectedTransformations, setInitialSelectedTransformations] = useState(
+    () => generateSelectedTransformations(selectedTransformations, generateSelectedTransformationsPredicate)
   );
   const [disabledRecordTypes, setDisabledRecordTypes] = useState({
     [FOLIO_RECORD_TYPES.SRS.type]: false,
@@ -119,6 +117,7 @@ export const MappingProfilesFormContainer = props => {
 
           setModalTransformations(() => ({ transformations: generateTransformationFieldsValues(allTransformations, newSelectedTransformations) }));
           setSelectedTransformations(newSelectedTransformations);
+          setInitialSelectedTransformations(generateSelectedTransformations(newSelectedTransformations, generateSelectedTransformationsPredicate));
         }}
       />
       <Callout ref={calloutRef} />

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -52,10 +52,10 @@ export const MappingProfilesFormContainer = props => {
   const [selectedTransformations, setSelectedTransformations] = useState(initialValues.transformations);
   const [modalTransformations, setModalTransformations] = useState({ transformations: generateTransformationFieldsValues(allTransformations, initialValues.transformations) });
   const calloutRef = useRef(null);
-  const generateSelectedTransformationsPredicate = selectedTransformation => modalTransformations.transformations
+  const getSelectedTransformationsInAllTransformations = selectedTransformation => modalTransformations.transformations
     .find(transformation => selectedTransformation.fieldId === transformation.fieldId);
   const [initialSelectedTransformations, setInitialSelectedTransformations] = useState(
-    () => generateSelectedTransformations(selectedTransformations, generateSelectedTransformationsPredicate)
+    () => generateSelectedTransformations(selectedTransformations, getSelectedTransformationsInAllTransformations)
   );
   const [disabledRecordTypes, setDisabledRecordTypes] = useState({
     [FOLIO_RECORD_TYPES.SRS.type]: false,
@@ -117,7 +117,7 @@ export const MappingProfilesFormContainer = props => {
 
           setModalTransformations(() => ({ transformations: generateTransformationFieldsValues(allTransformations, newSelectedTransformations) }));
           setSelectedTransformations(newSelectedTransformations);
-          setInitialSelectedTransformations(generateSelectedTransformations(newSelectedTransformations, generateSelectedTransformationsPredicate));
+          setInitialSelectedTransformations(generateSelectedTransformations(newSelectedTransformations, getSelectedTransformationsInAllTransformations));
         }}
       />
       <Callout ref={calloutRef} />

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -246,15 +246,13 @@ describe('MappingProfileFormContainer', () => {
         });
 
         describe('unchecking transformation, clicking cancel and reopening modal', () => {
-          beforeEach(() => {
+          it('should display correct selected field count', () => {
             const selectTransformationCheckboxes = screen.getAllByLabelText('Select field');
 
             userEvent.click(selectTransformationCheckboxes[0]);
             userEvent.click(getByRole(modal, 'button', { name: 'Cancel' }));
             userEvent.click(screen.getByRole('button', { name: 'Add transformations' }));
-          });
 
-          it('should display correct selected field count', () => {
             const totalSelected = document.querySelector('[data-test-transformations-total-selected]');
 
             expect(getByText(totalSelected, 'Total selected: 2')).toBeVisible();

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -244,6 +244,22 @@ describe('MappingProfileFormContainer', () => {
           expect(transformationFields[1].indicator2.value).toBe('');
           expect(transformationFields[1].subfield.value).toBe('$1');
         });
+
+        describe('unchecking transformation, clicking cancel and reopening modal', () => {
+          beforeEach(() => {
+            const selectTransformationCheckboxes = screen.getAllByLabelText('Select field');
+
+            userEvent.click(selectTransformationCheckboxes[0]);
+            userEvent.click(getByRole(modal, 'button', { name: 'Cancel' }));
+            userEvent.click(screen.getByRole('button', { name: 'Add transformations' }));
+          });
+
+          it('should display correct selected field count', () => {
+            const totalSelected = document.querySelector('[data-test-transformations-total-selected]');
+
+            expect(getByText(totalSelected, 'Total selected: 2')).toBeVisible();
+          });
+        });
       });
     });
   });

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.js
@@ -1,13 +1,10 @@
 import { omit } from 'lodash';
 
-import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
-import { isRawTransformationIsEmpty } from '../MappingProfilesTransformationsModal/validateTransformations';
+import { isInstanceTransformationEmpty } from '../MappingProfilesTransformationsModal/validateTransformations';
 
 export const parseRawTransformation = transformation => {
-  if (transformation.recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
-    if (isRawTransformationIsEmpty(transformation.rawTransformation)) {
-      return '';
-    }
+  if (isInstanceTransformationEmpty(transformation)) {
+    return '';
   }
 
   const { rawTransformation = {} } = transformation;

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.js
@@ -1,7 +1,15 @@
 import { omit } from 'lodash';
 
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
+import { isRawTransformationIsEmpty } from '../MappingProfilesTransformationsModal/validateTransformations';
+
 export const parseRawTransformation = transformation => {
-  // TODO: remove this check once transformations validation is done in scope of UIDEXP-187.
+  if (transformation.recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
+    if (isRawTransformationIsEmpty(transformation.rawTransformation)) {
+      return '';
+    }
+  }
+
   const { rawTransformation = {} } = transformation;
   const {
     marcField = '',
@@ -24,7 +32,7 @@ export const parseRawTransformation = transformation => {
 };
 
 export const splitIntoRawTransformation = transformation => {
-  const regex = /^(?<marcField>\d{3})(?<indicator1>[\d\s])(?<indicator2>[\d\s])(?<subfield>\$([0-9]{1,2}|[a-zA-Z]))?$/;
+  const regex = /^(?<marcField>\d{3})(?<indicator1>[\d\sa-zA-Z])(?<indicator2>[\d\sa-zA-Z])(?<subfield>\$([0-9]{1,2}|[a-zA-Z]))?$/;
   const rawTransformation = transformation.match(regex)?.groups;
 
   if (rawTransformation?.indicator1 === ' ') {

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/processRawTransformations.test.js
@@ -1,3 +1,5 @@
+import '../../../../test/jest/__mock__';
+
 import {
   omitRawTransformations,
   parseRawTransformation,

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -2,13 +2,15 @@ import React, {
   useState,
   useCallback,
   useEffect,
-  useRef, useMemo,
+  useRef,
+  useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   get,
   noop,
+  isEmpty,
 } from 'lodash';
 
 import {
@@ -30,6 +32,7 @@ import {
 import { TransformationsForm } from './TransformationsForm';
 import { SearchForm } from './SearchForm';
 import { normalizeTransformationFormValues } from './TransformationsField';
+import { validateTransformations } from './validateTransformations';
 
 import css from './MappingProfilesTransformationsModal.css';
 
@@ -65,6 +68,8 @@ export const MappingProfilesTransformationsModal = ({
     searchValue: initialSearchFormValues.searchValue,
     filters: searchFilters,
   }), [searchFilters]);
+  const [invalidTransformations, setInvalidTransformations] = useState({});
+  const [isSubmitButtonDisabled, setIsSubmitButtonDisabled] = useState(true);
 
   const resetSearchForm = useCallback(() => {
     setSearchFilters({
@@ -119,19 +124,41 @@ export const MappingProfilesTransformationsModal = ({
   })), []);
 
   const handleSelectChange = useCallback(
-    transformations => setSelectedTransformations(transformations),
-    []
-  );
+    transformations => {
+      if (isSubmitButtonDisabled) {
+        setIsSubmitButtonDisabled(false);
+      }
+
+      setSelectedTransformations(transformations);
+    }, [isSubmitButtonDisabled]);
 
   const handleSearchFormSubmit = useCallback(values => {
     setSearchValue(values.searchValue?.toLowerCase());
   }, []);
 
+  const handleCancel = () => {
+    setInvalidTransformations({});
+    setIsSubmitButtonDisabled(false);
+    setSelectedTransformations(initialSelectedTransformations);
+
+    onCancel();
+  };
+
   const handleSaveButtonClick = () => {
     const transformations = get(transformationsFormStateRef.current.getState(), 'values.transformations', []);
-    const normalizedTransformations = normalizeTransformationFormValues(transformations);
+    const validatedTransformations = validateTransformations(transformations);
 
-    onSubmit(normalizedTransformations);
+    if (isEmpty(validatedTransformations)) {
+      const normalizedTransformations = normalizeTransformationFormValues(transformations);
+
+      setInvalidTransformations({});
+      setIsSubmitButtonDisabled(false);
+
+      onSubmit(normalizedTransformations);
+    } else {
+      setInvalidTransformations(validatedTransformations);
+      setIsSubmitButtonDisabled(true);
+    }
   };
 
   const renderFooter = () => {
@@ -141,7 +168,7 @@ export const MappingProfilesTransformationsModal = ({
           data-test-transformations-cancel
           className="left"
           marginBottom0
-          onClick={onCancel}
+          onClick={handleCancel}
         >
           <FormattedMessage id="stripes-components.cancel" />
         </Button>
@@ -154,6 +181,7 @@ export const MappingProfilesTransformationsModal = ({
         <Button
           data-test-transformations-save
           buttonStyle="primary"
+          disabled={isSubmitButtonDisabled}
           marginBottom0
           onClick={handleSaveButtonClick}
         >
@@ -173,7 +201,7 @@ export const MappingProfilesTransformationsModal = ({
       dismissible
       enforceFocus={false}
       size="large"
-      onClose={onCancel}
+      onClose={handleCancel}
     >
       <Paneset>
         <Pane
@@ -210,7 +238,10 @@ export const MappingProfilesTransformationsModal = ({
             stateRef={transformationsFormStateRef}
             initialValues={initialTransformationsValues}
             searchResults={searchResults}
+            invalidTransformations={invalidTransformations}
             isSelectAllChecked={displayedCheckedItemsAmount === searchResults.length}
+            isSubmitButtonDisabled={isSubmitButtonDisabled}
+            setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
             onSelectChange={handleSelectChange}
             onSubmit={noop}
           />

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -130,7 +130,8 @@ export const MappingProfilesTransformationsModal = ({
       }
 
       setSelectedTransformations(transformations);
-    }, [isSubmitButtonDisabled]);
+    }, [isSubmitButtonDisabled]
+  );
 
   const handleSearchFormSubmit = useCallback(values => {
     setSearchValue(values.searchValue?.toLowerCase());
@@ -147,8 +148,9 @@ export const MappingProfilesTransformationsModal = ({
   const handleSaveButtonClick = () => {
     const transformations = get(transformationsFormStateRef.current.getState(), 'values.transformations', []);
     const validatedTransformations = validateTransformations(transformations);
+    const isTransformationFormValid = isEmpty(validatedTransformations);
 
-    if (isEmpty(validatedTransformations)) {
+    if (isTransformationFormValid) {
       const normalizedTransformations = normalizeTransformationFormValues(transformations);
 
       setInvalidTransformations({});

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { noop } from 'lodash';
+import {
+  getByRole,
+  getByText,
+  screen,
+  getAllByRole,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '../../../../test/jest/__mock__';
+
+import { renderWithIntl } from '@folio/stripes-data-transfer-components/test/jest/helpers';
+import { Layer } from '@folio/stripes/components';
+
+import {
+  SettingsComponentBuilder,
+  getTransformationFieldGroups,
+} from '../../../../test/jest/helpers';
+import { translationsProperties } from '../../../../test/helpers';
+import { MappingProfilesTransformationsModal } from './MappingProfilesTransformationsModal';
+
+const initialValues = {
+  transformations: [
+    {
+      displayName: 'Holdings - Effective call number',
+      recordType: 'HOLDINGS',
+      fieldId: 'field1',
+      order: 0,
+    },
+    {
+      displayName: 'Instances - Call number - prefix',
+      recordType: 'INSTANCE',
+      fieldId: 'field2',
+      order: 1,
+    },
+    {
+      displayName: 'Items - Electronic access - Link text Items',
+      recordType: 'ITEM',
+      fieldId: 'field3',
+      order: 2,
+    },
+  ],
+};
+
+const MappingProfilesTransformationModalContainer = ({
+  isOpen = true,
+  initialTransformationsValues = initialValues,
+  initialSelectedTransformations = {},
+  disabledRecordTypes = {},
+  onCancel = noop,
+  onSubmit = noop,
+}) => {
+  return (
+    <SettingsComponentBuilder>
+      <Layer
+        isOpen
+        contentLabel="label"
+      >
+        <MappingProfilesTransformationsModal
+          isOpen={isOpen}
+          initialTransformationsValues={initialTransformationsValues}
+          initialSelectedTransformations={initialSelectedTransformations}
+          disabledRecordTypes={disabledRecordTypes}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        />
+      </Layer>
+    </SettingsComponentBuilder>
+  );
+};
+
+describe('MappingProfilesTransformationsModal', () => {
+  describe('rendering mapping profile transformations modal', () => {
+    const onSubmitMock = jest.fn();
+    let modal;
+
+    beforeEach(() => {
+      renderWithIntl(
+        <MappingProfilesTransformationModalContainer
+          onSubmit={onSubmitMock}
+        />,
+        translationsProperties
+      );
+      modal = document.querySelector('[data-test-transformations-modal]');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should display transformations modal', () => {
+      expect(modal).toBeInTheDocument();
+    });
+
+    it('should display search pane', () => {
+      expect(modal.querySelector('[data-test-transformations-search-pane]')).toBeInTheDocument();
+    });
+
+    it('should display results pane', () => {
+      const resultsPane = modal.querySelector('[data-test-transformations-results-pane]');
+
+      expect(resultsPane).toBeInTheDocument();
+      expect(getByText(resultsPane, 'Transformations')).toBeInTheDocument();
+      expect(getByText(resultsPane, `${initialValues.transformations.length} fields found`)).toBeInTheDocument();
+    });
+
+    it('should display total selected count', () => {
+      expect(getByText(modal, 'Total selected: 0')).toBeInTheDocument();
+    });
+
+    it('should display search form', () => {
+      expect(modal.querySelector('[data-test-transformations-search-form]')).toBeInTheDocument();
+    });
+
+    it('should display correct folio record types', () => {
+      const checkboxes = getAllByRole(modal, 'checkbox');
+
+      expect(checkboxes[0].value).toBe('INSTANCE');
+      expect(checkboxes[1].value).toBe('HOLDINGS');
+      expect(checkboxes[2].value).toBe('ITEM');
+    });
+
+    it('should display cancel button', () => {
+      expect(getByRole(modal, 'button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('should display save button', () => {
+      expect(getByRole(modal, 'button', { name: 'Save & close' })).toBeInTheDocument();
+    });
+
+    describe('filling transformation values', () => {
+      let transformationFields;
+      let submitButton;
+
+      beforeEach(() => {
+        transformationFields = getTransformationFieldGroups();
+        submitButton = getByRole(modal, 'button', { name: 'Save & close' });
+        userEvent.type(transformationFields[0].marcField, '123');
+        userEvent.type(transformationFields[0].indicator1, '1');
+        userEvent.type(transformationFields[0].indicator2, '0');
+        userEvent.type(transformationFields[0].subfield, '$r');
+      });
+
+      it('should enable submit button', () => {
+        expect(submitButton).not.toBeDisabled();
+      });
+
+      it('should validate fields as valid and initiate modal submit', () => {
+        userEvent.click(submitButton);
+
+        expect(onSubmitMock).toBeCalled();
+      });
+
+      describe('selecting all fields and clicking submit', () => {
+        beforeEach(() => {
+          userEvent.click(screen.getByLabelText('Select all fields'));
+          userEvent.click(submitButton);
+          transformationFields = getTransformationFieldGroups();
+        });
+
+        it('should not initiate modal submit', () => {
+          expect(onSubmitMock).not.toBeCalled();
+        });
+
+        it('should disable submit button', () => {
+          expect(submitButton).toBeDisabled();
+        });
+
+        it('should validate instance record type transformation as valid (instances can be empty)', () => {
+          expect(transformationFields[1].isInvalid).toBe(false);
+        });
+
+        it('should validate item record type transformation as invalid', () => {
+          expect(transformationFields[2].isInvalid).toBe(true);
+        });
+
+        describe('filling empty invalid field with invalid transformation', () => {
+          beforeEach(() => {
+            userEvent.type(transformationFields[2].marcField, '123');
+            userEvent.type(transformationFields[2].subfield, '12');
+            userEvent.click(submitButton);
+            transformationFields = getTransformationFieldGroups();
+          });
+
+          it('should mark field as invalid', () => {
+            expect(transformationFields[2].isInvalid).toBe(true);
+          });
+        });
+
+        describe('filling empty invalid field with valid transformation', () => {
+          beforeEach(() => {
+            userEvent.type(transformationFields[2].marcField, '900');
+            userEvent.type(transformationFields[2].indicator1, 'r');
+            userEvent.type(transformationFields[2].indicator2, '1');
+            userEvent.type(transformationFields[2].subfield, '$90');
+            userEvent.click(submitButton);
+          });
+
+          it('should validate fields as valid and initiate modal submit', () => {
+            expect(onSubmitMock).toBeCalledWith([{
+              enabled: true,
+              fieldId: 'field1',
+              rawTransformation: {
+                marcField: '123',
+                indicator1: '1',
+                indicator2: '0',
+                subfield: '$r',
+              },
+              recordType: 'HOLDINGS',
+              transformation: '12310$r',
+            }, {
+              enabled: true,
+              fieldId: 'field2',
+              recordType: 'INSTANCE',
+              transformation: '',
+            }, {
+              enabled: true,
+              fieldId: 'field3',
+              rawTransformation: {
+                marcField: '900',
+                indicator1: 'r',
+                indicator2: '1',
+                subfield: '$90',
+              },
+              recordType: 'ITEM',
+              transformation: '900r1$90',
+            }]);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
@@ -10,16 +10,16 @@
   width: 29%;
 
   &:nth-of-type(4) {
-      margin-right: calc(var(--font-size-x-small)*2);
-   }
+    margin-right: calc(var(--font-size-x-small)*2);
+  }
 
   &.indicator {
-     width: 21%;
-     min-width: 55px;
-   }
+    width: 21%;
+    min-width: 55px;
+  }
 }
 
 .icon {
-  color: var(--error);
   margin-left: -1.4rem;
+  color: var(--error);
 }

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
@@ -1,3 +1,5 @@
+@import '@folio/stripes-components/lib/variables';
+
 .fieldGroupWrap {
   display: flex;
 }
@@ -7,8 +9,17 @@
   margin-left: 0.5rem;
   width: 29%;
 
+  &:nth-of-type(4) {
+      margin-right: calc(var(--font-size-x-small)*2);
+   }
+
   &.indicator {
      width: 21%;
      min-width: 55px;
    }
+}
+
+.icon {
+  color: var(--error);
+  margin-left: -1.4rem;
 }

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
@@ -1,59 +1,105 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import { TextField } from '@folio/stripes-components';
+import {
+  TextField,
+  Popover,
+  IconButton,
+} from '@folio/stripes-components';
 
 import css from './TransformationFieldGroup.css';
 
-export const TransformationFieldGroup = ({ record }) => {
+export const TransformationFieldGroup = ({
+  record,
+  isTransformationInvalid = false,
+  isSubmitButtonDisabled,
+  setIsSubmitButtonDisabled,
+}) => {
+  const intl = useIntl();
+
+  const handleChange = useCallback(() => {
+    if (isSubmitButtonDisabled) {
+      setIsSubmitButtonDisabled(false);
+    }
+  }, [isSubmitButtonDisabled, setIsSubmitButtonDisabled]);
+
+  const renderTransformationField = ({
+    name,
+    testId,
+    maxLength,
+    isIndicator = false,
+  }) => (
+    <div
+      className={classNames(css.field, { [css.indicator]: isIndicator })}
+      data-testid={testId}
+    >
+      <Field
+        name={name}
+        render={fieldProps => (
+          <TextField
+            {...fieldProps.input}
+            maxLength={maxLength}
+            marginBottom0
+            onChange={event => {
+              handleChange();
+              fieldProps.input.onChange(event);
+            }}
+          />
+        )}
+      />
+    </div>
+  );
+
   return (
     <div
       key={record.displayName}
       className={css.fieldGroupWrap}
       data-testid="transformation-field-group"
     >
-      <div
-        className={css.field}
-        data-testid="transformation-marcField"
-      >
-        <Field
-          component={TextField}
-          name={`transformations[${record.order}].rawTransformation.marcField`}
-          marginBottom0
-        />
-      </div>
-      <div
-        className={classNames(css.field, css.indicator)}
-        data-testid="transformation-indicator1"
-      >
-        <Field
-          component={TextField}
-          name={`transformations[${record.order}].rawTransformation.indicator1`}
-          marginBottom0
-        />
-      </div>
-      <div
-        className={classNames(css.field, css.indicator)}
-        data-testid="transformation-indicator2"
-      >
-        <Field
-          component={TextField}
-          name={`transformations[${record.order}].rawTransformation.indicator2`}
-          marginBottom0
-        />
-      </div>
-      <div
-        className={css.field}
-        data-testid="transformation-subfield"
-      >
-        <Field
-          component={TextField}
-          name={`transformations[${record.order}].rawTransformation.subfield`}
-          marginBottom0
-        />
-      </div>
+      {renderTransformationField({
+        name: `transformations[${record.order}].rawTransformation.marcField`,
+        testId: 'transformation-marcField',
+        maxLength: 3,
+      })}
+      {renderTransformationField({
+        name: `transformations[${record.order}].rawTransformation.indicator1`,
+        testId: 'transformation-indicator1',
+        maxLength: 1,
+        isIndicator: true,
+      })}
+      {renderTransformationField({
+        name: `transformations[${record.order}].rawTransformation.indicator2`,
+        testId: 'transformation-indicator2',
+        maxLength: 1,
+        isIndicator: true,
+      })}
+      {renderTransformationField({
+        name: `transformations[${record.order}].rawTransformation.subfield`,
+        testId: 'transformation-subfield',
+        maxLength: 3,
+      })}
+      {isTransformationInvalid && (
+        <Popover
+          renderTrigger={({
+            ref,
+            toggle,
+          }) => (
+            <IconButton
+              icon="times-circle-solid"
+              size="small"
+              className={css.icon}
+              ref={ref}
+              data-testid="transformation-invalid"
+              onClick={toggle}
+            />
+          )}
+        >
+          {intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.invalidTransformationMessage' })}
+        </Popover>
+      )}
     </div>
   );
 };
@@ -63,4 +109,7 @@ TransformationFieldGroup.propTypes = {
     displayName: PropTypes.string.isRequired,
     order: PropTypes.number.isRequired,
   }).isRequired,
+  isTransformationInvalid: PropTypes.bool,
+  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setIsSubmitButtonDisabled: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
@@ -19,7 +19,10 @@ const visibleColumns = ['isSelected', 'fieldName', 'transformation'];
 
 export const TransformationField = React.memo(({
   contentData,
-  isSelectAllChecked,
+  invalidTransformations = {},
+  isSelectAllChecked = false,
+  isSubmitButtonDisabled,
+  setIsSubmitButtonDisabled,
   onSelectChange,
   onSelectAll,
 }) => {
@@ -27,7 +30,7 @@ export const TransformationField = React.memo(({
   const headerRowHeight = 40;
   const rowHeight = 50;
 
-  const formatter = useMemo(() => ({
+  const formatter = {
     isSelected: record => (
       <Field
         key={record.displayName}
@@ -51,9 +54,14 @@ export const TransformationField = React.memo(({
     ),
     fieldName: record => record.displayName,
     transformation: record => (
-      <TransformationFieldGroup record={record} />
+      <TransformationFieldGroup
+        record={record}
+        isTransformationInvalid={invalidTransformations[record.order]}
+        isSubmitButtonDisabled={isSubmitButtonDisabled}
+        setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
+      />
     ),
-  }), [intl, onSelectChange]);
+  };
 
   const selectAllLabel = useMemo(() => intl.formatMessage({ id: 'ui-data-export.mappingProfiles.transformations.selectAllFields' }), [intl]);
 
@@ -100,11 +108,12 @@ export const TransformationField = React.memo(({
   );
 });
 
-TransformationField.defaultProps = { isSelectAllChecked: false };
-
 TransformationField.propTypes = {
   contentData: PropTypes.arrayOf(PropTypes.object.isRequired),
+  invalidTransformations: PropTypes.objectOf(PropTypes.bool),
   isSelectAllChecked: PropTypes.bool,
+  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setIsSubmitButtonDisabled: PropTypes.func.isRequired,
   onSelectChange: PropTypes.func.isRequired,
   onSelectAll: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
@@ -17,7 +17,10 @@ import commonCss from '../../../../common/common.css';
 const TransformationsFormComponent = memo(({
   searchResults,
   form,
+  invalidTransformations = {},
   isSelectAllChecked,
+  isSubmitButtonDisabled,
+  setIsSubmitButtonDisabled,
   stateRef,
   onSelectChange,
 }) => {
@@ -50,7 +53,10 @@ const TransformationsFormComponent = memo(({
     <form className={commonCss.fullScreen}>
       <TransformationField
         contentData={searchResults}
+        invalidTransformations={invalidTransformations}
         isSelectAllChecked={isSelectAllChecked}
+        isSubmitButtonDisabled={isSubmitButtonDisabled}
+        setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
         onSelectChange={handleSelectChange}
         onSelectAll={handleSelectAll}
       />
@@ -60,9 +66,12 @@ const TransformationsFormComponent = memo(({
 
 TransformationsFormComponent.propTypes = {
   searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
+  invalidTransformations: PropTypes.objectOf(PropTypes.bool),
   isSelectAllChecked: PropTypes.bool,
   form: PropTypes.object.isRequired,
   stateRef: PropTypes.object,
+  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setIsSubmitButtonDisabled: PropTypes.func.isRequired,
   onSelectChange: PropTypes.func.isRequired,
 };
 

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
@@ -1,0 +1,66 @@
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
+
+const transformationRegexMap = {
+  marcField: /^\d{3}$/,
+  indicator: /^[\d\sa-zA-Z]?$/,
+  subfield: /^(\$([0-9]{1,2}|[a-zA-Z]))?$/,
+};
+
+export const isRawTransformationIsEmpty = rawTransformation => {
+  if (!rawTransformation) {
+    return true;
+  }
+
+  const {
+    marcField = '',
+    indicator1 = '',
+    indicator2 = '',
+    subfield = '',
+  } = rawTransformation;
+
+  return `${marcField}${indicator1}${indicator2}${subfield}` === '';
+};
+
+export const validateRawTransformation = transformation => {
+  if (transformation.recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
+    if (isRawTransformationIsEmpty(transformation.rawTransformation)) {
+      return true;
+    }
+  }
+
+  if (transformation.rawTransformation) {
+    const {
+      rawTransformation: {
+        marcField,
+        indicator1 = '',
+        indicator2 = '',
+        subfield = '',
+      },
+    } = transformation;
+
+    return (
+      transformationRegexMap.marcField.test(marcField) &&
+      transformationRegexMap.indicator.test(indicator1) &&
+      transformationRegexMap.indicator.test(indicator2) &&
+      transformationRegexMap.subfield.test(subfield)
+    );
+  }
+
+  return false;
+};
+
+export const validateTransformations = transformations => {
+  const modifiedTransformations = transformations.filter(transformation => transformation.rawTransformation || transformation.isSelected);
+
+  const invalidTransformations = {};
+
+  modifiedTransformations.forEach(transformation => {
+    const isTransformationValid = validateRawTransformation(transformation);
+
+    if (!isTransformationValid) {
+      invalidTransformations[transformation.order] = true;
+    }
+  });
+
+  return invalidTransformations;
+};

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
@@ -6,7 +6,17 @@ const transformationRegexMap = {
   subfield: /^(\$([0-9]{1,2}|[a-zA-Z]))?$/,
 };
 
-export const isRawTransformationIsEmpty = rawTransformation => {
+export const isInstanceTransformationEmpty = transformation => {
+  if (transformation.recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
+    if (isRawTransformationEmpty(transformation.rawTransformation)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const isRawTransformationEmpty = rawTransformation => {
   if (!rawTransformation) {
     return true;
   }
@@ -22,10 +32,8 @@ export const isRawTransformationIsEmpty = rawTransformation => {
 };
 
 export const validateRawTransformation = transformation => {
-  if (transformation.recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
-    if (isRawTransformationIsEmpty(transformation.rawTransformation)) {
-      return true;
-    }
+  if (isInstanceTransformationEmpty(transformation)) {
+    return true;
   }
 
   if (transformation.rawTransformation) {
@@ -51,7 +59,6 @@ export const validateRawTransformation = transformation => {
 
 export const validateTransformations = transformations => {
   const modifiedTransformations = transformations.filter(transformation => transformation.rawTransformation || transformation.isSelected);
-
   const invalidTransformations = {};
 
   modifiedTransformations.forEach(transformation => {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
@@ -3,7 +3,7 @@ import '../../../../test/jest/__mock__';
 import {
   validateTransformations,
   validateRawTransformation,
-  isRawTransformationIsEmpty,
+  isRawTransformationEmpty, isInstanceTransformationEmpty,
 } from './validateTransformations';
 
 describe('validateRawTransformation', () => {
@@ -44,13 +44,13 @@ describe('validateRawTransformation', () => {
     expect(validateRawTransformation(transformation)).toBe(false);
   });
 
-  it('should validate raw transformation as invalid when marcField length is not less than 3', () => {
+  it('should validate raw transformation as invalid when marcField length is less than 3', () => {
     const transformation = { rawTransformation: { marcField: '13' } };
 
     expect(validateRawTransformation(transformation)).toBe(false);
   });
 
-  it('should validate raw transformation as invalid when marcField length is not more than 3', () => {
+  it('should validate raw transformation as invalid when marcField length is more than 3', () => {
     const transformation = { rawTransformation: { marcField: '1344' } };
 
     expect(validateRawTransformation(transformation)).toBe(false);
@@ -203,7 +203,7 @@ describe('validateRawTransformation', () => {
 });
 
 describe('validateTransformations', () => {
-  it('should return correct invalidTransformations', () => {
+  it('should return correct invalid transformations', () => {
     const transformations = [
       {
         isSelected: true,
@@ -250,24 +250,24 @@ describe('validateTransformations', () => {
   });
 });
 
-describe('isRawTransformationIsEmpty', () => {
+describe('isRawTransformationEmpty', () => {
   it('should return true when passing undefined', () => {
-    expect(isRawTransformationIsEmpty(undefined)).toBe(true);
+    expect(isRawTransformationEmpty(undefined)).toBe(true);
   });
 
   it('should return true when passing empty object', () => {
-    expect(isRawTransformationIsEmpty({})).toBe(true);
+    expect(isRawTransformationEmpty({})).toBe(true);
   });
 
   it('should return true when passing object with some empty fields present', () => {
-    expect(isRawTransformationIsEmpty({
+    expect(isRawTransformationEmpty({
       marcField: '',
       subfield: '',
     })).toBe(true);
   });
 
-  it('should return true when passing object with some all fields present', () => {
-    expect(isRawTransformationIsEmpty({
+  it('should return true when passing object with all fields present', () => {
+    expect(isRawTransformationEmpty({
       marcField: '',
       indicator1: '',
       indicator2: '',
@@ -275,11 +275,45 @@ describe('isRawTransformationIsEmpty', () => {
     })).toBe(true);
   });
 
-  it('should return false when passing object non empty fields', () => {
-    expect(isRawTransformationIsEmpty({
+  it('should return false when passing object with non empty fields', () => {
+    expect(isRawTransformationEmpty({
       marcField: 'abc',
       indicator1: '',
       subfield: '',
     })).toBe(false);
+  });
+});
+
+describe('isInstanceTransformationEmpty', () => {
+  it('should return true, when empty instance transformation is passed', () => {
+    const transformation = {
+      recordType: 'INSTANCE',
+      rawTransformation: {
+        marcField: '',
+        indicator1: '',
+        indicator2: '',
+        subfield: '',
+      },
+    };
+
+    expect(isInstanceTransformationEmpty(transformation)).toBe(true);
+  });
+
+  it('should return false, when non empty instance transformation is passed', () => {
+    const transformation = {
+      recordType: 'INSTANCE',
+      rawTransformation: { marcField: 'abc' },
+    };
+
+    expect(isInstanceTransformationEmpty(transformation)).toBe(false);
+  });
+
+  it('should return false, when non instance transformation is passed', () => {
+    const transformation = {
+      recordType: 'ITEM',
+      rawTransformation: { marcField: 'abc' },
+    };
+
+    expect(isInstanceTransformationEmpty(transformation)).toBe(false);
   });
 });

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
@@ -1,0 +1,285 @@
+import '../../../../test/jest/__mock__';
+
+import {
+  validateTransformations,
+  validateRawTransformation,
+  isRawTransformationIsEmpty,
+} from './validateTransformations';
+
+describe('validateRawTransformation', () => {
+  it('should validate raw transformation as valid when all fields are valid', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        indicator1: '0',
+        indicator2: '0',
+        subfield: '$13',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when indicator1 is empty and indicator2 is absent', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        indicator1: '',
+        subfield: '$13',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when indicators and subfield are absent', () => {
+    const transformation = { rawTransformation: { marcField: '300' } };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as invalid when marcField contains letters', () => {
+    const transformation = { rawTransformation: { marcField: '13a' } };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when marcField length is not less than 3', () => {
+    const transformation = { rawTransformation: { marcField: '13' } };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when marcField length is not more than 3', () => {
+    const transformation = { rawTransformation: { marcField: '1344' } };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when marcField is empty', () => {
+    const transformation = { rawTransformation: { marcField: '' } };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when marcField is absent', () => {
+    const transformation = { rawTransformation: {} };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when indicators have more than one character', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        indicator1: '12',
+        indicator2: 'aa',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as valid when indicators are letters', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        indicator1: 'a',
+        indicator2: 'B',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when indicators are whitespaces', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        indicator1: ' ',
+        indicator2: ' ',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when subfield contains $ and single digit', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$1',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when subfield contains $ and two digits', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$12',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when subfield contains $ and single letter', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$a',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as invalid when subfield contains $ and more than one letter', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$ab',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when subfield contains $ and more than two digits', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$900',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when subfield contains only $', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '$',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as invalid when subfield does not have $ at the beginning', () => {
+    const transformation = {
+      rawTransformation: {
+        marcField: '123',
+        subfield: '90',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(false);
+  });
+
+  it('should validate raw transformation as valid when all fields are absent and record has an instance type', () => {
+    const transformation = { recordType: 'INSTANCE' };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+
+  it('should validate raw transformation as valid when all fields are present but empty and record has an instance type', () => {
+    const transformation = {
+      recordType: 'INSTANCE',
+      rawTransformation: {
+        marcField: '',
+        indicator1: '',
+        indicator2: '',
+        subfield: '',
+      },
+    };
+
+    expect(validateRawTransformation(transformation)).toBe(true);
+  });
+});
+
+describe('validateTransformations', () => {
+  it('should return correct invalidTransformations', () => {
+    const transformations = [
+      {
+        isSelected: true,
+        order: 0,
+        recordType: 'HOLDINGS',
+      },
+      {
+        isSelected: true,
+        order: 1,
+        recordType: 'HOLDINGS',
+        rawTransformation: {
+          indicator1: '0',
+          indicator2: '0',
+          marcField: '123',
+          subfield: '$t',
+        },
+      },
+      {
+        order: 2,
+        rawTransformation: {
+          indicator1: 't',
+          marcField: '325',
+        },
+        recordType: 'HOLDINGS',
+      },
+      {
+        isSelected: false,
+        order: 3,
+        recordType: 'HOLDINGS',
+      },
+      {
+        isSelected: true,
+        order: 4,
+        recordType: 'HOLDINGS',
+        rawTransformation: { marcField: 'ABC' },
+      },
+    ];
+    const invalidTransformations = {
+      0: true,
+      4: true,
+    };
+
+    expect(validateTransformations(transformations)).toMatchObject(invalidTransformations);
+  });
+});
+
+describe('isRawTransformationIsEmpty', () => {
+  it('should return true when passing undefined', () => {
+    expect(isRawTransformationIsEmpty(undefined)).toBe(true);
+  });
+
+  it('should return true when passing empty object', () => {
+    expect(isRawTransformationIsEmpty({})).toBe(true);
+  });
+
+  it('should return true when passing object with some empty fields present', () => {
+    expect(isRawTransformationIsEmpty({
+      marcField: '',
+      subfield: '',
+    })).toBe(true);
+  });
+
+  it('should return true when passing object with some all fields present', () => {
+    expect(isRawTransformationIsEmpty({
+      marcField: '',
+      indicator1: '',
+      indicator2: '',
+      subfield: '',
+    })).toBe(true);
+  });
+
+  it('should return false when passing object non empty fields', () => {
+    expect(isRawTransformationIsEmpty({
+      marcField: 'abc',
+      indicator1: '',
+      subfield: '',
+    })).toBe(false);
+  });
+});

--- a/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
+++ b/test/bigtest/tests/units/settings/EditMappingProfileRoute/EditMappingProfileRoute-test.js
@@ -307,6 +307,8 @@ describe('EditMappingProfileRoute', () => {
         await editMappingProfileRoute.form.addTransformationsButton.click();
         await wait();
         await editMappingProfileRoute.form.transformationsModal.transformations.checkboxes(1).clickInput();
+        await editMappingProfileRoute.form.transformationsModal.transformations.valuesFields(1).marcField.fillAndBlur('123');
+        await editMappingProfileRoute.form.transformationsModal.transformations.valuesFields(1).subfield.fillAndBlur('$r');
         await editMappingProfileRoute.form.transformationsModal.saveButton.click();
         await wait();
       });

--- a/test/jest/helpers/getTransformationFieldGroups.js
+++ b/test/jest/helpers/getTransformationFieldGroups.js
@@ -1,5 +1,6 @@
 import {
   getByTestId,
+  queryAllByTestId,
   screen,
 } from '@testing-library/react';
 
@@ -11,5 +12,6 @@ export const getTransformationFieldGroups = () => {
     indicator1: getByTestId(group, 'transformation-indicator1').querySelector('input'),
     indicator2: getByTestId(group, 'transformation-indicator2').querySelector('input'),
     subfield: getByTestId(group, 'transformation-subfield').querySelector('input'),
+    isInvalid: Boolean(queryAllByTestId(group, 'transformation-invalid').length),
   }));
 };

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -63,6 +63,7 @@
   "mappingProfiles.transformations.searchFields": "Search fields",
   "mappingProfiles.transformations.searchResultsCountHeader": "{count, number} {count, plural, one {field found} other {fields found}}",
   "mappingProfiles.transformations.emptyMessage": "No transformations found",
+  "mappingProfiles.transformations.invalidTransformationMessage": "Please check your input",
   "mappingProfiles.create.successCallout": "The field mapping profile <b>{name}</b> has been successfully <b>created</b>",
   "mappingProfiles.create.errorCallout": "There was an error while creating the field mapping profile <b>{name}</b>",
   "mappingProfiles.edit.successCallout": "The field mapping profile <b>{name}</b> has been successfully <b>saved</b>",


### PR DESCRIPTION
## Purpose
In scope of [UIDEXP-187](https://issues.folio.org/browse/UIDEXP-187).
Provided data entry validation for each element of the transformation text boxes.

**Validation rules:** 

1. MARC field should only contain 3 digits - this field is **required**.
2. Indicator fields can contain a single digit, letter, whitespace or be empty.
3. Subfield should start with **$** and be followed by single letter or one or two digits.
4. Transformations with **Instance**record type allowed to be empty.

**Validation scenarios:**

- Should occur for every filled and/or checked transformation on sumbit.
- In case of failed validation, every failed transformation should have a red mark.
![image](https://user-images.githubusercontent.com/69502158/101788312-9d506180-3b08-11eb-85be-da1bcae873b7.png)
-  In case of failed validation, submit button should be disabled until some changes were made to the transformation form

## Jest coverage
![image](https://user-images.githubusercontent.com/69502158/101796634-caedd880-3b11-11eb-8a61-16c11a188c01.png)
![image](https://user-images.githubusercontent.com/69502158/101796562-b3165480-3b11-11eb-9892-c87ab5d1bf92.png)
![image](https://user-images.githubusercontent.com/69502158/101796773-f53f9600-3b11-11eb-9c89-a5b534577578.png)
![image](https://user-images.githubusercontent.com/69502158/101796795-fbce0d80-3b11-11eb-88e6-cea98528bd14.png)
