### PR TITLE
UIDEXP-187: Replace Row component with Layout in CheckboxGroupField

### DIFF
--- a/src/settings/MappingProfiles/CheckboxGroupField/CheckboxGroupField.js
+++ b/src/settings/MappingProfiles/CheckboxGroupField/CheckboxGroupField.js
@@ -5,7 +5,7 @@ import { Field } from 'react-final-form';
 
 import {
   Checkbox,
-  Row,
+  Layout,
 } from '@folio/stripes/components';
 
 export const CheckboxGroupField = memo(({
@@ -26,7 +26,7 @@ export const CheckboxGroupField = memo(({
             value={option.value}
             isEqual={isEqual}
             render={fieldProps => (
-              <Row>
+              <Layout className="display-flex">
                 <Checkbox
                   {...fieldProps.input}
                   label={option.label}
@@ -38,7 +38,7 @@ export const CheckboxGroupField = memo(({
                   }}
                 />
                 {option.details}
-              </Row>
+              </Layout>
             )}
           />
         </div>


### PR DESCRIPTION
## Purpose
In scope of [UIDEXP-187](https://issues.folio.org/browse/UIDEXP-187)

Replace `Row` component with `Layout`, as Row was sticking out of the container.

## Screenshots
![image](https://user-images.githubusercontent.com/69502158/101896802-34bdbf00-3bb2-11eb-8d7a-cf698f0f9712.png)
