### PR TITLE
UIDEXP-211: Display title only for instances on error logs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Move pretender to dev dependencies. UIDEXP-186.
 * Change failed job row click behavior, so it redirects to a page within same tab. UIDEXP-200.
 * Add validation to the mapping profile transformations. UIDEXP-187.
+* Display title only for instances on error logs page. UIDEXP-211.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.js
@@ -1,30 +1,42 @@
 import { capitalize } from 'lodash';
 
-function populateAffectedRecords(records, result) {
+import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
+
+const populateAffectedRecords = (records, result) => {
   if (!records) return;
 
   records.forEach(record => {
-    const recordType = capitalize(record.recordType);
+    const recordType = formatRecordType(record.recordType);
 
     result.push(`"Associated ${recordType} UUID": "${record.id}"`);
     result.push(`"Associated ${recordType} HRID": "${record.hrid}"`);
 
+    generateHRIDIfInstanceRecord(record, result);
     populateAffectedRecords(record.affectedRecords, result);
   });
-}
+};
 
-export function generateAffectedRecordInfo(affectedRecord) {
+export const generateAffectedRecordInfo = affectedRecord => {
   const result = ['{'];
-
-  const recordType = capitalize(affectedRecord.recordType);
+  const recordType = formatRecordType(affectedRecord.recordType);
 
   result.push(`"${recordType} UUID": "${affectedRecord.id}"`);
   result.push(`"${recordType} HRID": "${affectedRecord.hrid}"`);
-  result.push(`"${recordType} Title": "${affectedRecord.title}"`);
 
+  generateHRIDIfInstanceRecord(affectedRecord, result);
   populateAffectedRecords(affectedRecord.affectedRecords, result);
 
   result.push('}');
 
   return result;
-}
+};
+
+const generateHRIDIfInstanceRecord = (affectedRecord, result) => {
+  const { recordType } = affectedRecord;
+
+  if (recordType === FOLIO_RECORD_TYPES.INSTANCE.type) {
+    result.push(`"${formatRecordType(recordType)} Title": "${affectedRecord.title}"`);
+  }
+};
+
+const formatRecordType = recordType => capitalize(recordType);

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
@@ -1,8 +1,9 @@
+import '../../../../test/jest/__mock__';
 import { generateAffectedRecordInfo } from './generateAffectedRecordInfo';
 import { errorLogs } from '../../../../test/bigtest/fixtures/errorLogs';
 
 describe('generateAffectedRecordInfo', () => {
-  it('should return correct record info with no nesting', () => {
+  it('should return correct instance record info without affected records (affectedRecords field is provided but empty)', () => {
     const logs = {
       id: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
       hrid: 'inst000000000022',
@@ -16,6 +17,22 @@ describe('generateAffectedRecordInfo', () => {
       '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Instance HRID": "inst000000000022"',
       '"Instance Title": "A semantic web primer"',
+      '}',
+    ]);
+  });
+
+  it('should return correct item record info without affected records (affectedRecords field is not provided)', () => {
+    const logs = {
+      id: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+      hrid: 'inst000000000022',
+      title: 'A semantic web primer',
+      recordType: 'ITEM',
+    };
+
+    expect(generateAffectedRecordInfo(logs)).toEqual([
+      '{',
+      '"Item UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
+      '"Item HRID": "inst000000000022"',
       '}',
     ]);
   });
@@ -57,6 +74,31 @@ describe('generateAffectedRecordInfo', () => {
       '"Associated Item HRID": "item000000000015"',
       '"Associated Item UUID": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"',
       '"Associated Item HRID": "item000000000014"',
+      '}',
+    ]);
+  });
+
+  it('should provide title only for instance', () => {
+    const logs = {
+      id: '5bf370e0-8cca-4d9c-82e4-5170ab2a0a39',
+      hrid: 'inst000000000022',
+      recordType: 'HOLDINGS',
+      affectedRecords: [{
+        id: 'e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19',
+        hrid: 'hold000000000009',
+        title: 'A semantic web primer',
+        recordType: 'INSTANCE',
+        affectedRecords: [],
+      }],
+    };
+
+    expect(generateAffectedRecordInfo(logs)).toEqual([
+      '{',
+      '"Holdings UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
+      '"Holdings HRID": "inst000000000022"',
+      '"Associated Instance UUID": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"',
+      '"Associated Instance HRID": "hold000000000009"',
+      '"Instance Title": "A semantic web primer"',
       '}',
     ]);
   });

--- a/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
+++ b/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
@@ -81,7 +81,6 @@ describe('DuplicateMappingProfileRoute', () => {
     });
 
     it('should have enabled save button if there are no changes', () => {
-      screen.debug(screen.getByRole('button', { name: 'Save & close' }));
       expect(screen.getByRole('button', { name: 'Save & close' })).toBeEnabled();
     });
 


### PR DESCRIPTION
## Purpose

Display title only for instances on error logs page in the scope of the [UIDEXP-211](https://issues.folio.org/browse/UIDEXP-211).

## Jest coverage
<img width="1450" alt="Screen Shot 2020-12-15 at 3 14 41 PM" src="https://user-images.githubusercontent.com/40821852/102219557-4c65b200-3ee8-11eb-97a3-6e6668eae248.png">
