### PR TITLE
UIDEXP-220: Add a visual cue to invalid entry on transformation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Display title only for instances on error logs page. UIDEXP-211.
 * Replace translation keys with translations on Error logs page. UIDEXP-213.
 * Fix incorrect field validation when clearing filled transformation. UIDEXP-217.
+* Add a visual cue to invalid entry on transformation form. UIDEXP-220.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
+++ b/src/settings/MappingProfiles/DuplicateMappingProfileRoute/DuplicateMappingProfileRoute.test.js
@@ -100,10 +100,10 @@ describe('DuplicateMappingProfileRoute', () => {
       userEvent.click(screen.getByRole('button', { name: 'Add transformations' }));
       const transformationFields = getTransformationFieldGroups();
 
-      expect(transformationFields[2].marcField.value).toBe('900');
-      expect(transformationFields[2].indicator1.value).toBe('');
-      expect(transformationFields[2].indicator2.value).toBe('1');
-      expect(transformationFields[2].subfield.value).toBe('$12');
+      expect(transformationFields[2].marcField.input.value).toBe('900');
+      expect(transformationFields[2].indicator1.input.value).toBe('');
+      expect(transformationFields[2].indicator2.input.value).toBe('1');
+      expect(transformationFields[2].subfield.input.value).toBe('$12');
     });
 
     it('should not show validation error when clearing transformation with empty indicator field', () => {
@@ -111,9 +111,9 @@ describe('DuplicateMappingProfileRoute', () => {
       const transformationFields = getTransformationFieldGroups();
       const modal = document.querySelector('[data-test-transformations-modal]');
 
-      userEvent.type(transformationFields[2].marcField, '');
-      userEvent.type(transformationFields[0].indicator2, '');
-      userEvent.type(transformationFields[0].subfield, '');
+      userEvent.type(transformationFields[2].marcField.input, '');
+      userEvent.type(transformationFields[0].indicator2.input, '');
+      userEvent.type(transformationFields[0].subfield.input, '');
 
       userEvent.click(screen.getByLabelText('Select all fields'));
       userEvent.click(screen.getByLabelText('Select all fields'));

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -157,13 +157,13 @@ describe('MappingProfileFormContainer', () => {
         transformationFields = getTransformationFieldGroups();
         modal = document.querySelector('.modalRoot');
 
-        userEvent.type(transformationFields[0].marcField, '123');
-        userEvent.type(transformationFields[0].indicator1, '1');
-        userEvent.type(transformationFields[0].indicator2, '0');
-        userEvent.type(transformationFields[0].subfield, '$r');
+        userEvent.type(transformationFields[0].marcField.input, '123');
+        userEvent.type(transformationFields[0].indicator1.input, '1');
+        userEvent.type(transformationFields[0].indicator2.input, '0');
+        userEvent.type(transformationFields[0].subfield.input, '$r');
 
-        userEvent.type(transformationFields[1].marcField, '900');
-        userEvent.type(transformationFields[1].subfield, '$1');
+        userEvent.type(transformationFields[1].marcField.input, '900');
+        userEvent.type(transformationFields[1].subfield.input, '$1');
 
         userEvent.click(getByRole(modal, 'button', { name: 'Save & close' }));
 
@@ -233,16 +233,16 @@ describe('MappingProfileFormContainer', () => {
         });
 
         it('should display correct transformation fields values', () => {
-          expect(transformationFields[0].marcField.value).toBe('123');
-          expect(transformationFields[0].indicator1.value).toBe('1');
-          expect(transformationFields[0].indicator2.value).toBe('0');
-          expect(transformationFields[0].subfield.value).toBe('$r');
+          expect(transformationFields[0].marcField.input.value).toBe('123');
+          expect(transformationFields[0].indicator1.input.value).toBe('1');
+          expect(transformationFields[0].indicator2.input.value).toBe('0');
+          expect(transformationFields[0].subfield.input.value).toBe('$r');
 
-          expect(transformationFields[1].marcField.value).toBe('900');
-          expect(transformationFields[1].indicator1.value).toBe('');
-          expect(transformationFields[1].indicator2.value).toBe('');
-          expect(transformationFields[1].indicator2.value).toBe('');
-          expect(transformationFields[1].subfield.value).toBe('$1');
+          expect(transformationFields[1].marcField.input.value).toBe('900');
+          expect(transformationFields[1].indicator1.input.value).toBe('');
+          expect(transformationFields[1].indicator2.input.value).toBe('');
+          expect(transformationFields[1].indicator2.input.value).toBe('');
+          expect(transformationFields[1].subfield.input.value).toBe('$1');
         });
 
         describe('unchecking transformation, clicking cancel and reopening modal', () => {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -68,7 +68,7 @@ export const MappingProfilesTransformationsModal = ({
     searchValue: initialSearchFormValues.searchValue,
     filters: searchFilters,
   }), [searchFilters]);
-  const [invalidTransformations, setInvalidTransformations] = useState({});
+  const [validatedTransformations, setValidatedTransformations] = useState({});
   const [isSubmitButtonDisabled, setIsSubmitButtonDisabled] = useState(true);
 
   const resetSearchForm = useCallback(() => {
@@ -138,7 +138,7 @@ export const MappingProfilesTransformationsModal = ({
   }, []);
 
   const handleCancel = () => {
-    setInvalidTransformations({});
+    setValidatedTransformations({});
     setIsSubmitButtonDisabled(false);
     setSelectedTransformations(initialSelectedTransformations);
 
@@ -147,18 +147,18 @@ export const MappingProfilesTransformationsModal = ({
 
   const handleSaveButtonClick = () => {
     const transformations = get(transformationsFormStateRef.current.getState(), 'values.transformations', []);
-    const validatedTransformations = validateTransformations(transformations);
-    const isTransformationFormValid = isEmpty(validatedTransformations);
+    const invalidTransformations = validateTransformations(transformations);
+    const isTransformationFormValid = isEmpty(invalidTransformations);
 
     if (isTransformationFormValid) {
       const normalizedTransformations = normalizeTransformationFormValues(transformations);
 
-      setInvalidTransformations({});
+      setValidatedTransformations({});
       setIsSubmitButtonDisabled(false);
 
       onSubmit(normalizedTransformations);
     } else {
-      setInvalidTransformations(validatedTransformations);
+      setValidatedTransformations(invalidTransformations);
       setIsSubmitButtonDisabled(true);
     }
   };
@@ -240,7 +240,7 @@ export const MappingProfilesTransformationsModal = ({
             stateRef={transformationsFormStateRef}
             initialValues={initialTransformationsValues}
             searchResults={searchResults}
-            invalidTransformations={invalidTransformations}
+            validatedTransformations={validatedTransformations}
             isSelectAllChecked={displayedCheckedItemsAmount === searchResults.length}
             isSubmitButtonDisabled={isSubmitButtonDisabled}
             setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
@@ -136,10 +136,10 @@ describe('MappingProfilesTransformationsModal', () => {
       beforeEach(() => {
         transformationFields = getTransformationFieldGroups();
         submitButton = getByRole(modal, 'button', { name: 'Save & close' });
-        userEvent.type(transformationFields[0].marcField, '123');
-        userEvent.type(transformationFields[0].indicator1, '1');
-        userEvent.type(transformationFields[0].indicator2, '0');
-        userEvent.type(transformationFields[0].subfield, '$r');
+        userEvent.type(transformationFields[0].marcField.input, '123');
+        userEvent.type(transformationFields[0].indicator1.input, '1');
+        userEvent.type(transformationFields[0].indicator2.input, '0');
+        userEvent.type(transformationFields[0].subfield.input, '$r');
       });
 
       it('should enable submit button', () => {
@@ -171,33 +171,46 @@ describe('MappingProfilesTransformationsModal', () => {
           expect(transformationFields[1].isInvalid).toBe(false);
         });
 
-        it('should validate item record type transformation as invalid', () => {
+        it('should validate item record type transformation and mark marcField as invalid', () => {
           expect(transformationFields[2].isInvalid).toBe(true);
+          expect(transformationFields[2].marcField.isInvalid).toBe(true);
+          expect(transformationFields[2].indicator1.isInvalid).toBe(false);
+          expect(transformationFields[2].indicator2.isInvalid).toBe(false);
+          expect(transformationFields[2].subfield.isInvalid).toBe(false);
         });
 
         describe('filling empty invalid field with invalid transformation', () => {
           beforeEach(() => {
-            userEvent.type(transformationFields[2].marcField, '123');
-            userEvent.type(transformationFields[2].subfield, '12');
+            userEvent.type(transformationFields[2].marcField.input, '123');
+            userEvent.type(transformationFields[2].subfield.input, '12');
             userEvent.click(submitButton);
             transformationFields = getTransformationFieldGroups();
           });
 
-          it('should mark field as invalid', () => {
+          it('should mark transformation field group and subfield as invalid', () => {
             expect(transformationFields[2].isInvalid).toBe(true);
+            expect(transformationFields[2].marcField.isInvalid).toBe(false);
+            expect(transformationFields[2].indicator1.isInvalid).toBe(false);
+            expect(transformationFields[2].indicator2.isInvalid).toBe(false);
+            expect(transformationFields[2].subfield.isInvalid).toBe(true);
           });
         });
 
         describe('filling empty invalid field with valid transformation', () => {
           beforeEach(() => {
-            userEvent.type(transformationFields[2].marcField, '900');
-            userEvent.type(transformationFields[2].indicator1, 'r');
-            userEvent.type(transformationFields[2].indicator2, '1');
-            userEvent.type(transformationFields[2].subfield, '$90');
+            userEvent.type(transformationFields[2].marcField.input, '900');
+            userEvent.type(transformationFields[2].indicator1.input, 'r');
+            userEvent.type(transformationFields[2].indicator2.input, '1');
+            userEvent.type(transformationFields[2].subfield.input, '$90');
             userEvent.click(submitButton);
           });
 
           it('should validate fields as valid and initiate modal submit', () => {
+            transformationFields = getTransformationFieldGroups();
+            expect(transformationFields[2].marcField.isInvalid).toBe(false);
+            expect(transformationFields[2].indicator1.isInvalid).toBe(false);
+            expect(transformationFields[2].indicator2.isInvalid).toBe(false);
+            expect(transformationFields[2].subfield.isInvalid).toBe(false);
             expect(onSubmitMock).toBeCalledWith([{
               enabled: true,
               fieldId: 'field1',

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.css
@@ -17,6 +17,10 @@
     width: 21%;
     min-width: 55px;
   }
+
+  &.isInvalid > div > div {
+    border-color: var(--error);
+  }
 }
 
 .icon {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
@@ -14,7 +14,13 @@ import css from './TransformationFieldGroup.css';
 
 export const TransformationFieldGroup = ({
   record,
-  isTransformationInvalid = false,
+  validatedTransformations = {
+    marcField: true,
+    indicator1: true,
+    indicator2: true,
+    subfield: true,
+    isTransformationValid: true,
+  },
   isSubmitButtonDisabled,
   setIsSubmitButtonDisabled,
 }) => {
@@ -31,9 +37,13 @@ export const TransformationFieldGroup = ({
     testId,
     maxLength,
     isIndicator = false,
+    isValid = true,
   }) => (
     <div
-      className={classNames(css.field, { [css.indicator]: isIndicator })}
+      className={classNames(css.field, {
+        [css.indicator]: isIndicator,
+        [css.isInvalid]: !isValid,
+      })}
       data-testid={testId}
     >
       <Field
@@ -42,6 +52,7 @@ export const TransformationFieldGroup = ({
           <TextField
             {...fieldProps.input}
             maxLength={maxLength}
+            aria-invalid={!isValid}
             marginBottom0
             onChange={event => {
               handleChange();
@@ -63,25 +74,29 @@ export const TransformationFieldGroup = ({
         name: `transformations[${record.order}].rawTransformation.marcField`,
         testId: 'transformation-marcField',
         maxLength: 3,
+        isValid: validatedTransformations.marcField,
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator1`,
         testId: 'transformation-indicator1',
         maxLength: 1,
         isIndicator: true,
+        isValid: validatedTransformations.indicator1,
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator2`,
         testId: 'transformation-indicator2',
         maxLength: 1,
         isIndicator: true,
+        isValid: validatedTransformations.indicator2,
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.subfield`,
         testId: 'transformation-subfield',
         maxLength: 3,
+        isValid: validatedTransformations.subfield,
       })}
-      {isTransformationInvalid && (
+      {!validatedTransformations.isTransformationValid && (
         <Popover
           renderTrigger={({
             ref,
@@ -109,7 +124,13 @@ TransformationFieldGroup.propTypes = {
     displayName: PropTypes.string.isRequired,
     order: PropTypes.number.isRequired,
   }).isRequired,
-  isTransformationInvalid: PropTypes.bool,
+  validatedTransformations: PropTypes.shape({
+    marcField: PropTypes.bool,
+    indicator1: PropTypes.bool,
+    indicator2: PropTypes.bool,
+    subfield: PropTypes.bool,
+    isTransformationValid: PropTypes.bool,
+  }),
   isSubmitButtonDisabled: PropTypes.bool.isRequired,
   setIsSubmitButtonDisabled: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
@@ -19,7 +19,7 @@ const visibleColumns = ['isSelected', 'fieldName', 'transformation'];
 
 export const TransformationField = React.memo(({
   contentData,
-  invalidTransformations = {},
+  validatedTransformations = {},
   isSelectAllChecked = false,
   isSubmitButtonDisabled,
   setIsSubmitButtonDisabled,
@@ -56,7 +56,7 @@ export const TransformationField = React.memo(({
     transformation: record => (
       <TransformationFieldGroup
         record={record}
-        isTransformationInvalid={invalidTransformations[record.order]}
+        validatedTransformations={validatedTransformations[record.order]}
         isSubmitButtonDisabled={isSubmitButtonDisabled}
         setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
       />
@@ -110,7 +110,12 @@ export const TransformationField = React.memo(({
 
 TransformationField.propTypes = {
   contentData: PropTypes.arrayOf(PropTypes.object.isRequired),
-  invalidTransformations: PropTypes.objectOf(PropTypes.bool),
+  validatedTransformations: PropTypes.objectOf(PropTypes.shape({
+    marcField: PropTypes.bool,
+    indicator1: PropTypes.bool,
+    indicator2: PropTypes.bool,
+    subfield: PropTypes.bool,
+  })),
   isSelectAllChecked: PropTypes.bool,
   isSubmitButtonDisabled: PropTypes.bool.isRequired,
   setIsSubmitButtonDisabled: PropTypes.func.isRequired,

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
@@ -17,7 +17,7 @@ import commonCss from '../../../../common/common.css';
 const TransformationsFormComponent = memo(({
   searchResults,
   form,
-  invalidTransformations = {},
+  validatedTransformations = {},
   isSelectAllChecked,
   isSubmitButtonDisabled,
   setIsSubmitButtonDisabled,
@@ -53,7 +53,7 @@ const TransformationsFormComponent = memo(({
     <form className={commonCss.fullScreen}>
       <TransformationField
         contentData={searchResults}
-        invalidTransformations={invalidTransformations}
+        validatedTransformations={validatedTransformations}
         isSelectAllChecked={isSelectAllChecked}
         isSubmitButtonDisabled={isSubmitButtonDisabled}
         setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
@@ -66,7 +66,12 @@ const TransformationsFormComponent = memo(({
 
 TransformationsFormComponent.propTypes = {
   searchResults: PropTypes.arrayOf(PropTypes.object).isRequired,
-  invalidTransformations: PropTypes.objectOf(PropTypes.bool),
+  validatedTransformations: PropTypes.objectOf(PropTypes.shape({
+    marcField: PropTypes.bool,
+    indicator1: PropTypes.bool,
+    indicator2: PropTypes.bool,
+    subfield: PropTypes.bool,
+  })),
   isSelectAllChecked: PropTypes.bool,
   form: PropTypes.object.isRequired,
   stateRef: PropTypes.object,

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
@@ -3,10 +3,20 @@ import '../../../../test/jest/__mock__';
 import {
   validateTransformations,
   validateRawTransformation,
-  isRawTransformationEmpty, isInstanceTransformationEmpty,
+  isRawTransformationEmpty,
+  isInstanceTransformationEmpty,
+  checkTransformationValidity,
 } from './validateTransformations';
 
 describe('validateRawTransformation', () => {
+  const validTransformation = {
+    marcField: true,
+    indicator1: true,
+    indicator2: true,
+    subfield: true,
+    isTransformationValid: true,
+  };
+
   it('should validate raw transformation as valid when all fields are valid', () => {
     const transformation = {
       rawTransformation: {
@@ -17,7 +27,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when indicator1 is empty and indicator2 is absent', () => {
@@ -29,43 +39,63 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when indicators and subfield are absent', () => {
     const transformation = { rawTransformation: { marcField: '300' } };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as invalid when marcField contains letters', () => {
     const transformation = { rawTransformation: { marcField: '13a' } };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      marcField: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when marcField length is less than 3', () => {
     const transformation = { rawTransformation: { marcField: '13' } };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      marcField: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when marcField length is more than 3', () => {
     const transformation = { rawTransformation: { marcField: '1344' } };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      marcField: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when marcField is empty', () => {
     const transformation = { rawTransformation: { marcField: '' } };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      marcField: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when marcField is absent', () => {
     const transformation = { rawTransformation: {} };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      marcField: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when indicators have more than one character', () => {
@@ -77,7 +107,12 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      indicator1: false,
+      indicator2: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as valid when indicators are letters', () => {
@@ -89,7 +124,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when indicators are whitespaces', () => {
@@ -101,7 +136,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when subfield contains $ and single digit', () => {
@@ -112,7 +147,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when subfield contains $ and two digits', () => {
@@ -123,7 +158,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as valid when subfield contains $ and single letter', () => {
@@ -134,7 +169,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual(validTransformation);
   });
 
   it('should validate raw transformation as invalid when subfield contains $ and more than one letter', () => {
@@ -145,7 +180,11 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      subfield: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when subfield contains $ and more than two digits', () => {
@@ -156,7 +195,11 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      subfield: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when subfield contains only $', () => {
@@ -167,7 +210,11 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      subfield: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as invalid when subfield does not have $ at the beginning', () => {
@@ -178,13 +225,17 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(false);
+    expect(validateRawTransformation(transformation)).toEqual({
+      ...validTransformation,
+      subfield: false,
+      isTransformationValid: false,
+    });
   });
 
   it('should validate raw transformation as valid when all fields are absent and record has an instance type', () => {
     const transformation = { recordType: 'INSTANCE' };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual({ isTransformationValid: true });
   });
 
   it('should validate raw transformation as valid when all fields are present but empty and record has an instance type', () => {
@@ -198,7 +249,7 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toBe(true);
+    expect(validateRawTransformation(transformation)).toEqual({ isTransformationValid: true });
   });
 });
 
@@ -242,8 +293,20 @@ describe('validateTransformations', () => {
       },
     ];
     const invalidTransformations = {
-      0: true,
-      4: true,
+      0: {
+        marcField: false,
+        indicator1: true,
+        indicator2: true,
+        subfield: true,
+        isTransformationValid: false,
+      },
+      4: {
+        marcField: false,
+        indicator1: true,
+        indicator2: true,
+        subfield: true,
+        isTransformationValid: false,
+      },
     };
 
     expect(validateTransformations(transformations)).toMatchObject(invalidTransformations);
@@ -315,5 +378,49 @@ describe('isInstanceTransformationEmpty', () => {
     };
 
     expect(isInstanceTransformationEmpty(transformation)).toBe(false);
+  });
+});
+
+describe('checkTransformationValidity', () => {
+  it('should return correct validity object when all fields are valid', () => {
+    const validatedTransformations = {
+      marcField: true,
+      indicator1: true,
+      indicator2: true,
+      subfield: true,
+    };
+
+    expect(checkTransformationValidity(validatedTransformations)).toEqual({
+      ...validatedTransformations,
+      isTransformationValid: true,
+    });
+  });
+
+  it('should return correct validity object when all fields are invalid', () => {
+    const validatedTransformations = {
+      marcField: false,
+      indicator1: false,
+      indicator2: false,
+      subfield: false,
+    };
+
+    expect(checkTransformationValidity(validatedTransformations)).toEqual({
+      ...validatedTransformations,
+      isTransformationValid: false,
+    });
+  });
+
+  it('should return correct validity object when both valid and invalid fields are present', () => {
+    const validatedTransformations = {
+      marcField: false,
+      indicator1: false,
+      indicator2: true,
+      subfield: true,
+    };
+
+    expect(checkTransformationValidity(validatedTransformations)).toEqual({
+      ...validatedTransformations,
+      isTransformationValid: false,
+    });
   });
 });

--- a/test/jest/helpers/getTransformationFieldGroups.js
+++ b/test/jest/helpers/getTransformationFieldGroups.js
@@ -8,10 +8,22 @@ export const getTransformationFieldGroups = () => {
   const allGroups = screen.getAllByTestId('transformation-field-group');
 
   return allGroups.map(group => ({
-    marcField: getByTestId(group, 'transformation-marcField').querySelector('input'),
-    indicator1: getByTestId(group, 'transformation-indicator1').querySelector('input'),
-    indicator2: getByTestId(group, 'transformation-indicator2').querySelector('input'),
-    subfield: getByTestId(group, 'transformation-subfield').querySelector('input'),
+    marcField: {
+      input: getByTestId(group, 'transformation-marcField').querySelector('input'),
+      isInvalid: getByTestId(group, 'transformation-marcField').classList.contains('isInvalid'),
+    },
+    indicator1: {
+      input: getByTestId(group, 'transformation-indicator1').querySelector('input'),
+      isInvalid: getByTestId(group, 'transformation-indicator1').classList.contains('isInvalid'),
+    },
+    indicator2: {
+      input: getByTestId(group, 'transformation-indicator2').querySelector('input'),
+      isInvalid: getByTestId(group, 'transformation-indicator2').classList.contains('isInvalid'),
+    },
+    subfield: {
+      input: getByTestId(group, 'transformation-subfield').querySelector('input'),
+      isInvalid: getByTestId(group, 'transformation-subfield').classList.contains('isInvalid'),
+    },
     isInvalid: Boolean(queryAllByTestId(group, 'transformation-invalid').length),
   }));
 };


### PR DESCRIPTION
## Purpose
In the scope of [UIDEXP](https://issues.folio.org/browse/UIDEXP-220).
After the validation fails, the user can be notified which field contains incorrect data by highlighting the textbox with invalid data.

## Screenshots
![image](https://user-images.githubusercontent.com/69502158/104187411-6c718e00-5420-11eb-9daf-589456cc9204.png)

## Jest coverage
![image](https://user-images.githubusercontent.com/69502158/104187666-d12ce880-5420-11eb-898f-f9ab2d8fb4eb.png)
![image](https://user-images.githubusercontent.com/69502158/104187803-00dbf080-5421-11eb-8e62-6fe93d4b5c79.png)

