### PR TITLE
UIDEXP-218: Clear the validation error after user adjusts data entry in transformation field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix incorrect field validation when clearing filled transformation. UIDEXP-217.
 * Add a visual cue to invalid entry on transformation form. UIDEXP-220.
 * Update `stripes` to `v6.0.0`. UIDEXP-221.
+* Clear the validation error after user adjusts data entry in transformation field. UIDEXP-218.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.js
@@ -54,8 +54,8 @@ const fullWidthStyle = { style: { width: '100%' } };
 export const MappingProfilesTransformationsModal = ({
   isOpen,
   initialTransformationsValues,
-  initialSelectedTransformations,
-  disabledRecordTypes,
+  initialSelectedTransformations = {},
+  disabledRecordTypes = {},
   onCancel,
   onSubmit,
 }) => {
@@ -242,7 +242,7 @@ export const MappingProfilesTransformationsModal = ({
             searchResults={searchResults}
             validatedTransformations={validatedTransformations}
             isSelectAllChecked={displayedCheckedItemsAmount === searchResults.length}
-            isSubmitButtonDisabled={isSubmitButtonDisabled}
+            setValidatedTransformations={setValidatedTransformations}
             setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
             onSelectChange={handleSelectChange}
             onSubmit={noop}
@@ -260,9 +260,4 @@ MappingProfilesTransformationsModal.propTypes = {
   disabledRecordTypes: PropTypes.object,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-};
-
-MappingProfilesTransformationsModal.defaultProps = {
-  initialSelectedTransformations: {},
-  disabledRecordTypes: {},
 };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/MappingProfilesTransformationsModal.test.js
@@ -181,18 +181,38 @@ describe('MappingProfilesTransformationsModal', () => {
 
         describe('filling empty invalid field with invalid transformation', () => {
           beforeEach(() => {
-            userEvent.type(transformationFields[2].marcField.input, '123');
             userEvent.type(transformationFields[2].subfield.input, '12');
             userEvent.click(submitButton);
             transformationFields = getTransformationFieldGroups();
           });
 
-          it('should mark transformation field group and subfield as invalid', () => {
+          it('should mark transformation field group, marc field and subfield as invalid', () => {
             expect(transformationFields[2].isInvalid).toBe(true);
-            expect(transformationFields[2].marcField.isInvalid).toBe(false);
+            expect(transformationFields[2].marcField.isInvalid).toBe(true);
             expect(transformationFields[2].indicator1.isInvalid).toBe(false);
             expect(transformationFields[2].indicator2.isInvalid).toBe(false);
             expect(transformationFields[2].subfield.isInvalid).toBe(true);
+          });
+
+          describe('changing marc field', () => {
+            beforeEach(() => {
+              userEvent.type(transformationFields[2].marcField.input, '900');
+              transformationFields = getTransformationFieldGroups();
+            });
+
+            it('should mark marc field as valid and keep subfield and transformation group as invalid', () => {
+              expect(transformationFields[2].isInvalid).toBe(true);
+              expect(transformationFields[2].marcField.isInvalid).toBe(false);
+              expect(transformationFields[2].subfield.isInvalid).toBe(true);
+            });
+
+            it('should mark subfield as valid as well as transformation group after addressing every invalid field', () => {
+              userEvent.type(transformationFields[2].subfield.input, '$12');
+              transformationFields = getTransformationFieldGroups();
+
+              expect(transformationFields[2].isInvalid).toBe(false);
+              expect(transformationFields[2].subfield.isInvalid).toBe(false);
+            });
           });
         });
 

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
@@ -10,6 +10,8 @@ import {
   IconButton,
 } from '@folio/stripes-components';
 
+import { checkTransformationValidity } from '../../validateTransformations';
+
 import css from './TransformationFieldGroup.css';
 
 export const TransformationFieldGroup = ({
@@ -21,20 +23,31 @@ export const TransformationFieldGroup = ({
     subfield: true,
     isTransformationValid: true,
   },
-  isSubmitButtonDisabled,
+  setValidatedTransformations,
   setIsSubmitButtonDisabled,
 }) => {
   const intl = useIntl();
 
-  const handleChange = useCallback(() => {
-    if (isSubmitButtonDisabled) {
-      setIsSubmitButtonDisabled(false);
+  const handleChange = useCallback((type, isValid) => {
+    setIsSubmitButtonDisabled(isSubmitButtonDisabled => (isSubmitButtonDisabled ? false : isSubmitButtonDisabled));
+
+    if (!isValid) {
+      setValidatedTransformations(transformations => {
+        return {
+          ...transformations,
+          [record.order]: checkTransformationValidity({
+            ...transformations[record.order],
+            [type]: true,
+          }),
+        };
+      });
     }
-  }, [isSubmitButtonDisabled, setIsSubmitButtonDisabled]);
+  }, [record.order, setIsSubmitButtonDisabled, setValidatedTransformations]);
 
   const renderTransformationField = ({
     name,
     testId,
+    type,
     maxLength,
     isIndicator = false,
     isValid = true,
@@ -55,7 +68,7 @@ export const TransformationFieldGroup = ({
             aria-invalid={!isValid}
             marginBottom0
             onChange={event => {
-              handleChange();
+              handleChange(type, isValid);
               fieldProps.input.onChange(event);
             }}
           />
@@ -73,12 +86,14 @@ export const TransformationFieldGroup = ({
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.marcField`,
         testId: 'transformation-marcField',
+        type: 'marcField',
         maxLength: 3,
         isValid: validatedTransformations.marcField,
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator1`,
         testId: 'transformation-indicator1',
+        type: 'indicator1',
         maxLength: 1,
         isIndicator: true,
         isValid: validatedTransformations.indicator1,
@@ -86,6 +101,7 @@ export const TransformationFieldGroup = ({
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator2`,
         testId: 'transformation-indicator2',
+        type: 'indicator2',
         maxLength: 1,
         isIndicator: true,
         isValid: validatedTransformations.indicator2,
@@ -93,6 +109,7 @@ export const TransformationFieldGroup = ({
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.subfield`,
         testId: 'transformation-subfield',
+        type: 'subfield',
         maxLength: 3,
         isValid: validatedTransformations.subfield,
       })}
@@ -131,6 +148,6 @@ TransformationFieldGroup.propTypes = {
     subfield: PropTypes.bool,
     isTransformationValid: PropTypes.bool,
   }),
-  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setValidatedTransformations: PropTypes.func.isRequired,
   setIsSubmitButtonDisabled: PropTypes.func.isRequired,
 };

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
@@ -21,7 +21,7 @@ export const TransformationField = React.memo(({
   contentData,
   validatedTransformations = {},
   isSelectAllChecked = false,
-  isSubmitButtonDisabled,
+  setValidatedTransformations,
   setIsSubmitButtonDisabled,
   onSelectChange,
   onSelectAll,
@@ -57,7 +57,7 @@ export const TransformationField = React.memo(({
       <TransformationFieldGroup
         record={record}
         validatedTransformations={validatedTransformations[record.order]}
-        isSubmitButtonDisabled={isSubmitButtonDisabled}
+        setValidatedTransformations={setValidatedTransformations}
         setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
       />
     ),
@@ -117,7 +117,7 @@ TransformationField.propTypes = {
     subfield: PropTypes.bool,
   })),
   isSelectAllChecked: PropTypes.bool,
-  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setValidatedTransformations: PropTypes.func.isRequired,
   setIsSubmitButtonDisabled: PropTypes.func.isRequired,
   onSelectChange: PropTypes.func.isRequired,
   onSelectAll: PropTypes.func.isRequired,

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsForm/TransformationsForm.js
@@ -18,10 +18,10 @@ const TransformationsFormComponent = memo(({
   searchResults,
   form,
   validatedTransformations = {},
-  isSelectAllChecked,
-  isSubmitButtonDisabled,
-  setIsSubmitButtonDisabled,
+  isSelectAllChecked = false,
   stateRef,
+  setValidatedTransformations,
+  setIsSubmitButtonDisabled,
   onSelectChange,
 }) => {
   stateRef.current = form;
@@ -55,7 +55,7 @@ const TransformationsFormComponent = memo(({
         contentData={searchResults}
         validatedTransformations={validatedTransformations}
         isSelectAllChecked={isSelectAllChecked}
-        isSubmitButtonDisabled={isSubmitButtonDisabled}
+        setValidatedTransformations={setValidatedTransformations}
         setIsSubmitButtonDisabled={setIsSubmitButtonDisabled}
         onSelectChange={handleSelectChange}
         onSelectAll={handleSelectAll}
@@ -75,12 +75,10 @@ TransformationsFormComponent.propTypes = {
   isSelectAllChecked: PropTypes.bool,
   form: PropTypes.object.isRequired,
   stateRef: PropTypes.object,
-  isSubmitButtonDisabled: PropTypes.bool.isRequired,
+  setValidatedTransformations: PropTypes.func.isRequired,
   setIsSubmitButtonDisabled: PropTypes.func.isRequired,
   onSelectChange: PropTypes.func.isRequired,
 };
-
-TransformationsFormComponent.defaultProps = { isSelectAllChecked: false };
 
 export const TransformationsForm = stripesFinalForm({
   subscription: { values: false },


### PR DESCRIPTION
## Purpose
In the scope of [UIDEXP-218](https://issues.folio.org/browse/UIDEXP-218).
When the user adjusts their input after verification fails, the input should become valid. In case, when the last invalid field is adjusted, the transformation group should also hide the invalid icon.

## Jest coverage
![image](https://user-images.githubusercontent.com/69502158/104593607-9b823c80-5678-11eb-8b83-b471c9418afe.png)


## Screenshots
![ezgif com-gif-maker](https://user-images.githubusercontent.com/69502158/104595132-d4231580-567a-11eb-86b1-1af1dc2729ba.gif)
