### PR TITLE
UIDEXP-219: Add placeholder to the transformation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add a visual cue to invalid entry on transformation form. UIDEXP-220.
 * Update `stripes` to `v6.0.0`. UIDEXP-221.
 * Clear the validation error after user adjusts data entry in transformation field. UIDEXP-218.
+* Add placeholder to the transformation form. UIDEXP-219.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.test.js
@@ -6,6 +6,8 @@ import {
   getByText,
   screen,
   getAllByRole,
+  getByPlaceholderText,
+  queryByPlaceholderText,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -230,6 +232,34 @@ describe('MappingProfileFormContainer', () => {
           const totalSelected = document.querySelector('[data-test-transformations-total-selected]');
 
           expect(getByText(totalSelected, 'Total selected: 2')).toBeVisible();
+        });
+
+        it('should have correct placeholders', () => {
+          expect(transformationFields.length).toEqual(2);
+
+          expect(getByPlaceholderText(transformationFields[0].marcField.container, '900')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].indicator1.container, '0')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].indicator2.container, '0')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].subfield.container, '$a')).toBeInTheDocument();
+
+          expect(queryByPlaceholderText(transformationFields[1].marcField.container, '900')).toBeNull();
+          expect(queryByPlaceholderText(transformationFields[1].indicator1.container, '0')).toBeNull();
+          expect(queryByPlaceholderText(transformationFields[1].indicator2.container, '0')).toBeNull();
+          expect(queryByPlaceholderText(transformationFields[1].subfield.container, '$a')).toBeNull();
+        });
+
+        it('should have correct placeholders after the first transformation is selected and hidden after the selected items filter is unchecked', () => {
+          userEvent.click(screen.getAllByRole('checkbox', { name: 'Select field' })[0]);
+          userEvent.click(screen.getByRole('checkbox', { name: 'Selected' }));
+
+          transformationFields = getTransformationFieldGroups();
+
+          expect(transformationFields.length).toEqual(1);
+
+          expect(getByPlaceholderText(transformationFields[0].marcField.container, '900')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].indicator1.container, '0')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].indicator2.container, '0')).toBeInTheDocument();
+          expect(getByPlaceholderText(transformationFields[0].subfield.container, '$a')).toBeInTheDocument();
         });
 
         it('should display correct transformation fields values', () => {

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationFieldGroup/TransformationFieldGroup.js
@@ -14,6 +14,13 @@ import { checkTransformationValidity } from '../../validateTransformations';
 
 import css from './TransformationFieldGroup.css';
 
+const GROUP_PLACEHOLDER = {
+  marcField: '900',
+  indicator1: '0',
+  indicator2: '0',
+  subfield: '$a',
+};
+
 export const TransformationFieldGroup = ({
   record,
   validatedTransformations = {
@@ -27,6 +34,8 @@ export const TransformationFieldGroup = ({
   setIsSubmitButtonDisabled,
 }) => {
   const intl = useIntl();
+
+  const groupPlaceholder = record.isFirst ? GROUP_PLACEHOLDER : {};
 
   const handleChange = useCallback((type, isValid) => {
     setIsSubmitButtonDisabled(isSubmitButtonDisabled => (isSubmitButtonDisabled ? false : isSubmitButtonDisabled));
@@ -46,6 +55,7 @@ export const TransformationFieldGroup = ({
 
   const renderTransformationField = ({
     name,
+    placeholder,
     testId,
     type,
     maxLength,
@@ -64,6 +74,7 @@ export const TransformationFieldGroup = ({
         render={fieldProps => (
           <TextField
             {...fieldProps.input}
+            placeholder={placeholder}
             maxLength={maxLength}
             aria-invalid={!isValid}
             marginBottom0
@@ -85,6 +96,7 @@ export const TransformationFieldGroup = ({
     >
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.marcField`,
+        placeholder: groupPlaceholder.marcField,
         testId: 'transformation-marcField',
         type: 'marcField',
         maxLength: 3,
@@ -92,6 +104,7 @@ export const TransformationFieldGroup = ({
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator1`,
+        placeholder: groupPlaceholder.indicator1,
         testId: 'transformation-indicator1',
         type: 'indicator1',
         maxLength: 1,
@@ -100,6 +113,7 @@ export const TransformationFieldGroup = ({
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.indicator2`,
+        placeholder: groupPlaceholder.indicator2,
         testId: 'transformation-indicator2',
         type: 'indicator2',
         maxLength: 1,
@@ -108,6 +122,7 @@ export const TransformationFieldGroup = ({
       })}
       {renderTransformationField({
         name: `transformations[${record.order}].rawTransformation.subfield`,
+        placeholder: groupPlaceholder.subfield,
         testId: 'transformation-subfield',
         type: 'subfield',
         maxLength: 3,
@@ -140,6 +155,7 @@ TransformationFieldGroup.propTypes = {
   record: PropTypes.shape({
     displayName: PropTypes.string.isRequired,
     order: PropTypes.number.isRequired,
+    isFirst: PropTypes.bool,
   }).isRequired,
   validatedTransformations: PropTypes.shape({
     marcField: PropTypes.bool,

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/TransformationsField/TransformationsField.js
@@ -1,9 +1,15 @@
-import React, { useMemo } from 'react';
+import React, {
+  memo,
+  useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
-import { isEqual } from 'lodash';
+import {
+  isEqual,
+  isEmpty,
+} from 'lodash';
 
 import { Checkbox } from '@folio/stripes/components';
 
@@ -17,7 +23,7 @@ const columnWidths = {
 };
 const visibleColumns = ['isSelected', 'fieldName', 'transformation'];
 
-export const TransformationField = React.memo(({
+export const TransformationField = memo(({
   contentData,
   validatedTransformations = {},
   isSelectAllChecked = false,
@@ -84,7 +90,15 @@ export const TransformationField = React.memo(({
   }), [intl, isSelectAllChecked, onSelectAll, selectAllLabel]);
 
   const itemsData = useMemo(() => ({
-    contentData,
+    contentData: isEmpty(contentData)
+      ? contentData
+      : [
+        {
+          ...contentData[0],
+          isFirst: true,
+        },
+        ...contentData.slice(1),
+      ],
     formatter,
     visibleColumns,
     columnWidths,

--- a/test/jest/helpers/getTransformationFieldGroups.js
+++ b/test/jest/helpers/getTransformationFieldGroups.js
@@ -9,18 +9,22 @@ export const getTransformationFieldGroups = () => {
 
   return allGroups.map(group => ({
     marcField: {
+      container: getByTestId(group, 'transformation-marcField'),
       input: getByTestId(group, 'transformation-marcField').querySelector('input'),
       isInvalid: getByTestId(group, 'transformation-marcField').classList.contains('isInvalid'),
     },
     indicator1: {
+      container: getByTestId(group, 'transformation-indicator1'),
       input: getByTestId(group, 'transformation-indicator1').querySelector('input'),
       isInvalid: getByTestId(group, 'transformation-indicator1').classList.contains('isInvalid'),
     },
     indicator2: {
+      container: getByTestId(group, 'transformation-indicator2'),
       input: getByTestId(group, 'transformation-indicator2').querySelector('input'),
       isInvalid: getByTestId(group, 'transformation-indicator2').classList.contains('isInvalid'),
     },
     subfield: {
+      container: getByTestId(group, 'transformation-subfield'),
       input: getByTestId(group, 'transformation-subfield').querySelector('input'),
       isInvalid: getByTestId(group, 'transformation-subfield').classList.contains('isInvalid'),
     },


### PR DESCRIPTION
## Purpose

Add placeholder to the transformation form in the scope of the [UIDEXP-219](https://issues.folio.org/browse/UIDEXP-219).

## Screenshot
<img width="1102" alt="Screenshot 2021-01-15 at 17 43 37" src="https://user-images.githubusercontent.com/40821852/104747473-3f431980-5759-11eb-8a05-8e1a92885f46.png">

## Jest coverage
<img width="1675" alt="Screenshot 2021-01-15 at 17 36 14" src="https://user-images.githubusercontent.com/40821852/104746653-40c01200-5758-11eb-8bea-9193c9bce681.png">
