### PR TITLE
UIDEXP-203: Display a link to the inventory record on Error logs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Clear the validation error after user adjusts data entry in transformation field. UIDEXP-218.
 * Add placeholder to the transformation form. UIDEXP-219.
 * Use react-query for job profile details page. UIDEXP-224.
+* Display a link to the inventory record on Error logs page. UIDEXP-203.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/src/components/ErrorLogsView/ErrorLogsView.test.js
+++ b/src/components/ErrorLogsView/ErrorLogsView.test.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { getByText } from '@testing-library/react';
+import {
+  getByTestId,
+  getByText,
+  queryByTestId,
+} from '@testing-library/react';
 
 import '../../../test/jest/__mock__';
 
@@ -10,6 +14,8 @@ import { translationsProperties } from '../../../test/helpers';
 import { errorLogs } from '../../../test/bigtest/fixtures/errorLogs';
 
 describe('ErrorLogsView', () => {
+  let errorLogContainers;
+
   describe('rendering ErrorLogsView', () => {
     beforeEach(() => {
       renderWithIntl(
@@ -22,14 +28,26 @@ describe('ErrorLogsView', () => {
         />,
         translationsProperties
       );
+
+      errorLogContainers = document.querySelectorAll('[data-test-error-log]');
     });
 
     it('should render correct error info', () => {
-      const errorLogContainers = document.querySelectorAll('[data-test-error-log]');
-
       expect(getByText(errorLogContainers[0], `${errorLogs[0].createdDate} ${errorLogs[0].logLevel} An error occurred during fields mapping for srs record with id: ${errorLogs[0].errorMessageValues[0]}, reason: ${errorLogs[0].errorMessageValues[1]}, cause: ${errorLogs[0].errorMessageValues[2]}`)).toBeInTheDocument();
       expect(getByText(errorLogContainers[1], `${errorLogs[1].createdDate} ${errorLogs[1].logLevel} UUIDs not found in SRS or inventory: ${errorLogs[1].errorMessageValues[0]}`)).toBeInTheDocument();
       expect(getByText(errorLogContainers[2], `${errorLogs[2].createdDate} ${errorLogs[2].logLevel} Error while getting holdings by instance id: ${errorLogs[2].errorMessageValues[0]}, message: ${errorLogs[2].errorMessageValues[1]}`)).toBeInTheDocument();
+    });
+
+    it('should display record link', () => {
+      const link = getByTestId(errorLogContainers[2], 'record-link');
+
+      expect(link).toBeInTheDocument();
+      expect(link.href).toEqual(errorLogs[2].affectedRecord.inventoryRecordLink);
+      expect(getByText(link, errorLogs[2].affectedRecord.inventoryRecordLink)).toBeInTheDocument();
+    });
+
+    it('should not display a link, if its not present in affected record', () => {
+      expect(queryByTestId(errorLogContainers[0], 'record-link')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.js
@@ -1,5 +1,7 @@
+import React from 'react';
 import { capitalize } from 'lodash';
 
+import { TextLink } from '@folio/stripes/components';
 import { FOLIO_RECORD_TYPES } from '@folio/stripes-data-transfer-components';
 
 const populateAffectedRecords = ({
@@ -73,6 +75,21 @@ const generateAffectedRecordLevel = ({
         recordType,
       }
     ));
+  }
+
+  if (record.inventoryRecordLink) {
+    affectedRecordLevel.push(
+      <>
+        {formatMessage({ id: 'ui-data-export.errorLogs.inventoryRecordLink' })}
+        <TextLink
+          href={record.inventoryRecordLink}
+          target="_blank"
+          data-testId="record-link"
+        >
+          {record.inventoryRecordLink}
+        </TextLink>
+      </>
+    );
   }
 
   return affectedRecordLevel;

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
@@ -79,8 +79,7 @@ describe('generateAffectedRecordInfo', () => {
 
   it('should return correct record info with 2 level nesting', () => {
     const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs: errorLogs[2].affectedRecord }], translationsProperties);
-
-    expect(recordInfo).toEqual([
+    const generatedRecord = [
       '{',
       '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Instance HRID": "inst000000000022"',
@@ -92,7 +91,9 @@ describe('generateAffectedRecordInfo', () => {
       '"Associated Item UUID": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"',
       '"Associated Item HRID": "item000000000014"',
       '}',
-    ]);
+    ];
+
+    expect(recordInfo).toMatchObject(expect.arrayContaining(generatedRecord));
   });
 
   it('should provide title only for instance', () => {

--- a/test/bigtest/fixtures/errorLogs.js
+++ b/test/bigtest/fixtures/errorLogs.js
@@ -28,6 +28,7 @@ export const errorLogs = [
       hrid: 'inst000000000022',
       title: 'A semantic web primer',
       recordType: 'INSTANCE',
+      inventoryRecordLink: 'https://folio-snapshot-load.dev.folio.org/inventory/view/e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6',
       affectedRecords: [{
         id: 'e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19',
         hrid: 'hold000000000009',

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -102,6 +102,7 @@
   "errorLogs.recordAssociated.HRID": "\"Associated {recordType} HRID\": \"{value}\"",
   "errorLogs.recordAssociated.UUID": "\"Associated {recordType} UUID\": \"{value}\"",
   "errorLogs.recordAssociated.Title": "\"Associated {recordType} Title\": \"{value}\"",
+  "errorLogs.inventoryRecordLink": "\"Inventory record link\": ",
 
   "instance.electronic.access.linkText.default": "Instance - Electronic access - Link Text",
   "instance.electronic.access.materialsSpecification.default": "Instance - Electronic access - Materials specified",


### PR DESCRIPTION
## Purpose
When the export of the record fails, the user will need to investigate the reason for it. In order to make the navigation between logs and the affected record easier, the link to the inventory record will need to be created.

## Screenshot
![image](https://user-images.githubusercontent.com/69502158/106926481-d0cef700-6719-11eb-9d33-6bc49a3aba9a.png)


## Jest coverage
![image](https://user-images.githubusercontent.com/69502158/107032134-fd3b4f80-67bb-11eb-850a-0fad15c72431.png)
