### PR TITLE
UIDEXP-227: Update `stripes-cli` to `v2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add placeholder to the transformation form. UIDEXP-219.
 * Use react-query for job profile details page. UIDEXP-224.
 * Display a link to the inventory record on Error logs page. UIDEXP-203.
+* Update `stripes-cli` to `v2.0.0`. UIDEXP-227.
 
 ## [3.0.2](https://github.com/folio-org/ui-data-export/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/tree/v3.0.1...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-core": "^7.0.0",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.4",


### PR DESCRIPTION
## Purpose

Update `stripes-cli` to `v2.0.0` in the scope of the [UIDEXP-227](https://issues.folio.org/browse/UIDEXP-227).