### PR TITLE
UIDEXP-255 use correct css-loader syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## IN PROGRESS
 
-*Select UUIDs type before starting export. UIDEXP-177
+* Select UUIDs type before starting export. UIDEXP-177
+* Use correct `css-loader` syntax. UIDEXP-255
 
 ## [5.0.0](https://github.com/folio-org/ui-data-export/tree/v4.0.0) (2021-10-08)
 [Full Changelog](https://github.com/folio-org/ui-data-export/compare/v4.1.0...v5.0.0)

--- a/src/components/MultiColumnList/GridCell/GridCell.css
+++ b/src/components/MultiColumnList/GridCell/GridCell.css
@@ -1,4 +1,4 @@
 .mclCell {
-  composes: mclCell from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
-  composes: mclCellStyle from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclCell from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclCellStyle from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
 }

--- a/src/components/MultiColumnList/GridRow/GridRow.css
+++ b/src/components/MultiColumnList/GridRow/GridRow.css
@@ -1,7 +1,7 @@
 .mclRow {
-  composes: mclRow from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclRow from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
 }
 
 .mclIsOdd {
-  composes: mclIsOdd from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclIsOdd from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
 }

--- a/src/components/MultiColumnList/HeaderGridRow/HeaderRow.css
+++ b/src/components/MultiColumnList/HeaderGridRow/HeaderRow.css
@@ -1,7 +1,7 @@
 .mclHeaderRow {
-  composes: mclHeaderRow from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclHeaderRow from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
 }
 
 .mclHeaderCell {
-  composes: mclHeader from '@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
+  composes: mclHeader from '~@folio/stripes-components/lib/MultiColumnList/MCLRenderer.css';
 }


### PR DESCRIPTION
Use the correct syntax when linking to styles in other packages.

@UladzislauKutarkin, @uladislausamets, @vashjs: please merge this if it looks good to you. I don't have write privileges in this repository. Thanks!

Refs [UIDEXP-255](https://issues.folio.org/browse/UIDEXP-255), [STRIPES-770](https://issues.folio.org/browse/STRIPES-770)