### PR TITLE
UIDEXP-264: Move focus to data export-pane header when Settings > Dat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * The list of errors is truncated. UIDEXP-259
 * Add total number of records to be exported to the Running component. UIDEXP-161
 * Refactor away from SafeHTMLMessage. UIDEXP-216
-
+* When go to Settings > Data export, change focus automatically to data-export pane header. UIDEXP-264
 
 ## [5.0.0](https://github.com/folio-org/ui-data-export/tree/v4.0.0) (2021-10-08)
 [Full Changelog](https://github.com/folio-org/ui-data-export/compare/v4.1.0...v5.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Refactor away from SafeHTMLMessage. UIDEXP-216
 * When go to Settings > Data export, change focus automatically to data-export pane header. UIDEXP-264
 
+
 ## [5.0.0](https://github.com/folio-org/ui-data-export/tree/v4.0.0) (2021-10-08)
 [Full Changelog](https://github.com/folio-org/ui-data-export/compare/v4.1.0...v5.0.0)
 * Mapping profiles list not ordered alphabetically on the new job profile form. UIDEXP-241.

--- a/src/settings/DataExportSettings/DataExportSettings.js
+++ b/src/settings/DataExportSettings/DataExportSettings.js
@@ -1,4 +1,7 @@
-import React, { useRef } from 'react';
+import React, {
+  useEffect,
+  useRef,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { Settings } from '@folio/stripes/smart-components';
@@ -48,6 +51,13 @@ const sections = [
 
 export function DataExportSettings(props) {
   const calloutRef = useRef(null);
+  const paneTitleRef = useRef(null);
+
+  useEffect(() => {
+    if (paneTitleRef.current) {
+      paneTitleRef.current.focus();
+    }
+  }, []);
 
   return (
     <>
@@ -57,6 +67,7 @@ export function DataExportSettings(props) {
           navPaneWidth="15%"
           sections={sections}
           paneTitle={<FormattedMessage id="ui-data-export.settings.index.paneTitle" />}
+          paneTitleRef={paneTitleRef}
         />
       </CalloutContext.Provider>
       <Callout ref={calloutRef} />


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIDEXP-239
 -->
 - When go to `Settings` > `Data export` , change focus automatically to `data-export` pane header.
 - Refs: https://issues.folio.org/browse/UIDEXP-264
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Pass `paneTitleRef` prop to `Settings` component to manage focus automatically.

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
