### PR TITLE
UIDEXP-304: Need new permission(s) to view Data Export settings in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
         "displayName": "Settings (Data export): Can view",
         "subPermissions": [
           "data-export.mapping-profiles.item.get",
+          "data-export.job-executions.items.download.get",
           "data-export.job-executions.collection.get",
           "data-export.job-profiles.collection.get",
           "data-export.job-profiles.item.get",

--- a/src/components/ProfileDetailsActionMenu/ProfileDetailsActionMenu.js
+++ b/src/components/ProfileDetailsActionMenu/ProfileDetailsActionMenu.js
@@ -6,7 +6,6 @@ import {
   Button,
   Icon,
 } from '@folio/stripes/components';
-import { useStripes } from '@folio/stripes/core';
 
 export const ProfileDetailsActionMenu = ({
   isProfileUsed,
@@ -22,16 +21,12 @@ export const ProfileDetailsActionMenu = ({
     onToggle();
   };
 
-  const stripes = useStripes();
-  const hasOnlyViewPerms = stripes.hasPerm('settings.data-export.view') && !stripes.hasPerm('settings.data-export.enabled');
-
-
   return (
     <>
       <Button
         data-test-edit-profile-button
         buttonStyle="dropdownItem"
-        disabled={isDefaultProfile || isProfileUsed || hasOnlyViewPerms}
+        disabled={isDefaultProfile || isProfileUsed}
         onClick={buildButtonClickHandler(onEdit)}
       >
         <Icon icon="edit">
@@ -42,7 +37,6 @@ export const ProfileDetailsActionMenu = ({
         data-test-duplicate-profile-button
         buttonStyle="dropdownItem"
         onClick={buildButtonClickHandler(onDuplicate)}
-        disabled={hasOnlyViewPerms}
       >
         <Icon icon="duplicate">
           <FormattedMessage id="stripes-data-transfer-components.duplicate" />
@@ -51,7 +45,7 @@ export const ProfileDetailsActionMenu = ({
       <Button
         data-test-delete-profile-button
         buttonStyle="dropdownItem"
-        disabled={isDefaultProfile || isProfileUsed || hasOnlyViewPerms}
+        disabled={isDefaultProfile || isProfileUsed}
         onClick={buildButtonClickHandler(onDelete)}
       >
         <Icon icon="trash">

--- a/src/settings/ProfileDetails/ProfileDetails.js
+++ b/src/settings/ProfileDetails/ProfileDetails.js
@@ -13,6 +13,7 @@ import {
   FullScreenView,
   Preloader,
 } from '@folio/stripes-data-transfer-components';
+import { useStripes } from '@folio/stripes/core';
 
 import { ProfileDetailsActionMenu } from '../../components/ProfileDetailsActionMenu';
 import { useProfileHandlerWithCallout } from '../utils/useProfileHandlerWithCallout';
@@ -45,6 +46,10 @@ export const ProfileDetails = props => {
     },
   });
 
+
+  const stripes = useStripes();
+  const hasOnlyViewPerms = stripes.hasPerm('settings.data-export.view') && !stripes.hasPerm('settings.data-export.enabled');
+
   const renderActionMenu = useCallback(({ onToggle }) => {
     return (
       <ProfileDetailsActionMenu
@@ -63,7 +68,7 @@ export const ProfileDetails = props => {
       id={`${type}-profile-details`}
       contentLabel={intl.formatMessage({ id: `ui-data-export.${type}Profiles.newProfile` })}
       paneTitle={profile?.name}
-      actionMenu={!isLoading && renderActionMenu}
+      actionMenu={!isLoading && !hasOnlyViewPerms && renderActionMenu}
       onCancel={onCancel}
     >
       {isLoading


### PR DESCRIPTION
[UIDEXP-304](https://issues.folio.org/browse/UIDEXP-304)
Here we hide the action menu if user have only view permission. In prev implementation, we were disabling buttons in action menu.  All other implementation was done before in scope of that ticket

Can't make a video since perms not working locally.
