### PR TITLE
UIDEXP-351: Cannot view Mapping profiles and Job profiles with "Settings (Data export): display list of settings pages" permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
         "subPermissions": [
           "settings.data-export.enabled",
           "data-export.mapping-profiles.collection.get",
-          "data-export.transformation-fields.collection.get"
+          "data-export.transformation-fields.collection.get",
+          "data-export.job-profiles.collection.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIDEXP-351
Here small fix to an existing story.