### PR TITLE
UIDEXP-366 Error message is displayed when go from Data export Settings to View All page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * UI adjustments for reworked Data Export. Refs UIDEXP-357.
 * Cannot view Mapping profiles and Job profiles with "Settings (Data export): display list of settings pages" permission. Refs UIDEXP-351.
 * Remove information icon from Settings > Data export > Profiles .Refs UIDEXP-363
+* Error message is displayed when go from Data export Settings to View All page. Refs UIDEXP-366.
 
 ## [6.0.0](https://github.com/folio-org/ui-data-export/tree/v6.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-data-export/compare/v5.4.1...v6.0.0)

--- a/src/hooks/useDefaultSorting.js
+++ b/src/hooks/useDefaultSorting.js
@@ -2,15 +2,21 @@ import { useEffect } from 'react';
 import { buildSearch } from '@folio/stripes-acq-components';
 import { useHistory } from 'react-router-dom';
 
+// eslint-disable-next-line import/prefer-default-export
 export const useDefaultSorting = () => {
   const history = useHistory();
 
   useEffect(() => {
+    history.replace({
+      search: `${buildSearch({
+        sort: 'name'
+      }, history.location.search)}`,
+    });
+
+    // clear search params on unmount to avoid conflicts with other components
     return () => {
       history.replace({
-        search: `${buildSearch({
-          sort: 'name'
-        }, history.location.search)}`,
+        search: '',
       });
     };
   }, []);


### PR DESCRIPTION
After this PR is merged, conflicts with search parameters will no longer arise since they will be cleared when the component is unmounted. Ref [UIDEXP-366](https://folio-org.atlassian.net/browse/UIDEXP-366)