### PR TITLE
UIDEXP-366 Clean only sort related search params

### DIFF
--- a/src/hooks/useDefaultSorting.js
+++ b/src/hooks/useDefaultSorting.js
@@ -7,17 +7,17 @@ export const useDefaultSorting = () => {
   const history = useHistory();
 
   useEffect(() => {
-    history.replace({
+    const setDefaultSort = (sort) => history.replace({
       search: `${buildSearch({
-        sort: 'name'
+        sort
       }, history.location.search)}`,
     });
 
-    // clear search params on unmount to avoid conflicts with other components
+    setDefaultSort('name');
+
+    // clear sort params on unmount to avoid conflicts with other components
     return () => {
-      history.replace({
-        search: '',
-      });
+      setDefaultSort(null);
     };
   }, []);
 };


### PR DESCRIPTION
As a part of https://github.com/folio-org/ui-data-export/pull/447 all search parameters were cleaned after component unmount, but it have to be only for sort-related parameters.

Note: CHANGELOG.MD was updated in initial PR