### PR TITLE
UIDEXP-377: Add info tip to field suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Display error messages instead of error codes in Data export. Refs UIDEXP-371.
 * Suppressing fields on export - integrate with BE. Refs UIDEXP-375.
 * Reliably show paginator on the 'View all' page. Refs UIDEXP-379.
+* Add info tip to field suppression. Refs UIDEXP-377
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
@@ -19,6 +19,7 @@ import {
   TextArea,
   Button,
   Checkbox,
+  InfoPopover,
 } from '@folio/stripes/components';
 import stripesFinalForm from '@folio/stripes/final-form';
 import { FOLIO_RECORD_TYPES, FullScreenForm } from '@folio/stripes-data-transfer-components';
@@ -66,6 +67,15 @@ const MappingProfilesFormComponent = props => {
   const isSubmitButtonDisabled = isFormDirty ? !isFormDirty : pristine || submitting;
   const recordTypes = form.getFieldState('recordTypes')?.value;
   const isFieldsSuppressionDisabled = !recordTypes?.length || recordTypes?.every(recordType => [FOLIO_RECORD_TYPES.ITEM.type].includes(recordType));
+  const fieldSuppressionFieldLabel = (
+    <span>
+      <FormattedMessage id="ui-data-export.fieldsSuppression" />
+      <InfoPopover
+        allowAnchorClick
+        content={<FormattedMessage id="ui-data-export.suppressInfo" />}
+      />
+    </span>
+  );
 
   // it's required clear field value when it became disabled
   useEffect(() => {
@@ -138,7 +148,7 @@ const MappingProfilesFormComponent = props => {
               <div data-test-mapping-profile-fieldsSuppression>
                 <Field
                   disabled={isFieldsSuppressionDisabled}
-                  label={<FormattedMessage id="ui-data-export.fieldsSuppression" />}
+                  label={fieldSuppressionFieldLabel}
                   name="fieldsSuppression"
                   id="mapping-profile-fieldsSuppression"
                   component={TextArea}

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -38,6 +38,7 @@
   "description": "Description",
   "fieldsSuppression": "Fields suppression",
   "suppress999ff": "Suppress 999 ff",
+  "suppressInfo": "List of MARC fields to be excluded from the export. The fields are represented by three digits and separated by a comma. For example: 902,903",
   "outputFormat": "Output format",
   "transformations": "Transformations",
   "uploading": "Uploading",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIDEXP-377
Here we added an info tip to the suppress field title.

https://github.com/folio-org/ui-data-export/assets/72550466/b7b7e536-af5a-4858-8574-f33a7c1f17fa

