### PR TITLE
UIDEXP-376 React v19: refactor away from default props for functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Display error messages instead of error codes in Data export. Refs UIDEXP-371.
 * Suppressing fields on export - integrate with BE. Refs UIDEXP-375.
 * Reliably show paginator on the 'View all' page. Refs UIDEXP-379.
+* React v19: refactor away from default props for functional components.фвв Refs UIDEXP-376.
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/src/components/ChooseJobProfile/ConfirmationModal/ConfirmationModal.js
+++ b/src/components/ChooseJobProfile/ConfirmationModal/ConfirmationModal.js
@@ -30,19 +30,22 @@ const propTypes = {
   open: PropTypes.bool.isRequired,
 };
 
-const defaultProps = {
-  bodyTag: 'div',
-  buttonStyle: 'primary',
-  cancelButtonStyle: 'default',
-  disabledCofirmButton: false,
-};
 
 const ConfirmationModal = props => {
-  const testId = props.id || uniqueId('confirmation-');
-  const cancelLabel = props.cancelLabel || <FormattedMessage id="stripes-components.cancel" />;
-  const confirmLabel = props.confirmLabel || <FormattedMessage id="stripes-components.submit" />;
   const {
-    bodyTag: Element,
+    bodyTag: Element = 'div',
+    buttonStyle = 'primary',
+    cancelButtonStyle = 'default',
+    disabledCofirmButton = false,
+    id = uniqueId('confirmation-'),
+    cancelLabel = <FormattedMessage id="stripes-components.cancel" />,
+    confirmLabel = <FormattedMessage id="stripes-components.submit" />,
+    onConfirm,
+    onCancel,
+    open,
+    heading,
+    ariaLabel,
+    message,
     ...rest
   } = props;
 
@@ -50,18 +53,18 @@ const ConfirmationModal = props => {
     <ModalFooter>
       <Button
         data-test-confirmation-modal-confirm-button
-        buttonStyle={props.buttonStyle}
-        disabled={props.disabledCofirmButton}
-        id={`clickable-${testId}-confirm`}
-        onClick={props.onConfirm}
+        buttonStyle={buttonStyle}
+        disabled={disabledCofirmButton}
+        id={`clickable-${id}-confirm`}
+        onClick={onConfirm}
       >
         {confirmLabel}
       </Button>
       <Button
         data-test-confirmation-modal-cancel-button
-        buttonStyle={props.cancelButtonStyle}
-        id={`clickable-${testId}-cancel`}
-        onClick={props.onCancel}
+        buttonStyle={cancelButtonStyle}
+        id={`clickable-${id}-cancel`}
+        onClick={onCancel}
       >
         {cancelLabel}
       </Button>
@@ -70,10 +73,10 @@ const ConfirmationModal = props => {
 
   return (
     <Modal
-      open={props.open}
-      id={testId}
-      label={props.heading}
-      aria-label={rest['aria-label'] || props.ariaLabel}
+      open={open}
+      id={id}
+      label={heading}
+      aria-label={rest['aria-label'] || ariaLabel}
       scope="module"
       size="small"
       footer={footer}
@@ -82,13 +85,12 @@ const ConfirmationModal = props => {
         data-test-confirmation-modal-message
         className={css.message}
       >
-        {props.message}
+        {message}
       </Element>
     </Modal>
   );
 };
 
 ConfirmationModal.propTypes = propTypes;
-ConfirmationModal.defaultProps = defaultProps;
 
 export default ConfirmationModal;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import { AllJobLogsView } from './components/AllJobLogsView';
 
 export default function DataExport(props) {
   const {
-    showSettings,
+    showSettings = false,
     match: { path },
   } = props;
 
@@ -52,5 +52,3 @@ DataExport.propTypes = {
   match: matchShape.isRequired,
   showSettings: PropTypes.bool,
 };
-
-DataExport.defaultProps = { showSettings: false };

--- a/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
+++ b/src/settings/JobProfiles/JobProfileDetails/JobProfileDetails.js
@@ -17,10 +17,10 @@ import { ProfileDetails } from '../../ProfileDetails';
 
 const JobProfileDetails = props => {
   const {
+    isLoading = false,
     jobProfile,
     mappingProfile,
     stripes,
-    isLoading,
     onEdit,
     onDuplicate,
   } = props;
@@ -100,7 +100,5 @@ JobProfileDetails.propTypes = {
   onDuplicate: PropTypes.func,
   onDelete: PropTypes.func.isRequired,
 };
-
-JobProfileDetails.defaultProps = { isLoading: false };
 
 export default JobProfileDetails;

--- a/src/settings/MappingProfiles/CheckboxGroupField/CheckboxGroupField.js
+++ b/src/settings/MappingProfiles/CheckboxGroupField/CheckboxGroupField.js
@@ -9,11 +9,11 @@ import {
 } from '@folio/stripes/components';
 
 export const CheckboxGroupField = memo(({
+  disabledFields = {},
   id,
   name,
   options,
   filtersLabelClass,
-  disabledFields,
   onChange,
 }) => {
   return (
@@ -55,5 +55,3 @@ CheckboxGroupField.propTypes = {
   filtersLabelClass: PropTypes.string,
   disabledFields: PropTypes.object,
 };
-
-CheckboxGroupField.defaultProps = { disabledFields: {} };

--- a/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
+++ b/src/settings/MappingProfiles/MappingProfileDetails/MappingProfileDetails.js
@@ -25,10 +25,10 @@ import css from './MappingProfileDetails.css';
 
 const MappingProfileDetails = props => {
   const {
+    isLoading = false,
     allTransformations,
     mappingProfile,
     stripes,
-    isLoading,
     onEdit,
     onDuplicate,
   } = props;
@@ -156,10 +156,6 @@ MappingProfileDetails.propTypes = {
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   onDuplicate: PropTypes.func.isRequired,
-};
-
-MappingProfileDetails.defaultProps = {
-  isLoading: false,
 };
 
 export default MappingProfileDetails;

--- a/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/FolioRecordTypeField/FolioRecordTypeField.js
@@ -18,7 +18,7 @@ import { CheckboxGroupField } from '../../CheckboxGroupField';
 import css from './FolioRecordTypeField.css';
 
 export const FolioRecordTypeField = memo(({
-  initiallyDisabledRecordTypes,
+  initiallyDisabledRecordTypes = {},
   onTypeDisable,
 }) => {
   const [touched, setTouched] = useState(false);
@@ -91,5 +91,3 @@ FolioRecordTypeField.propTypes = {
   initiallyDisabledRecordTypes: PropTypes.object,
   onTypeDisable: PropTypes.func.isRequired,
 };
-
-FolioRecordTypeField.defaultProps = { initiallyDisabledRecordTypes: {} };

--- a/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
@@ -46,13 +46,13 @@ const validate = values => {
 
 const MappingProfilesFormComponent = props => {
   const {
-    title,
+    isEditMode = false,
+    isFormDirty = false,
+    title = <FormattedMessage id="ui-data-export.mappingProfiles.newProfile" />,
     pristine,
     submitting,
     transformations,
     allTransformations,
-    isEditMode,
-    isFormDirty,
     form,
     initiallyDisabledRecordTypes,
     onAddTransformations,
@@ -204,12 +204,6 @@ MappingProfilesFormComponent.propTypes = {
   onAddTransformations: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   onTypeDisable: PropTypes.func.isRequired,
-};
-
-MappingProfilesFormComponent.defaultProps = {
-  isEditMode: false,
-  isFormDirty: false,
-  title: <FormattedMessage id="ui-data-export.mappingProfiles.newProfile" />,
 };
 
 export const MappingProfilesForm = stripesFinalForm({

--- a/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
+++ b/src/settings/MappingProfiles/MappingProfilesFormContainer/MappingProfilesFormContainer.js
@@ -43,9 +43,9 @@ const isValidRecordTypesMatching = (selectedTransformations = [], selectedRecord
 
 export const MappingProfilesFormContainer = props => {
   const {
+    isEditMode = false,
     allTransformations,
     contentLabel,
-    isEditMode,
     initialValues,
     onSubmit,
   } = props;
@@ -136,5 +136,3 @@ MappingProfilesFormContainer.propTypes = {
   isEditMode: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 };
-
-MappingProfilesFormContainer.defaultProps = { isEditMode: false };

--- a/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
+++ b/src/settings/MappingProfiles/TransformationsList/TransformationsList.js
@@ -18,7 +18,7 @@ const columnWidths = {
 const visibleColumns = ['fieldName', 'transformation'];
 
 export const TransformationsList = ({
-  transformations,
+  transformations = [],
   allTransformations,
 }) => {
   const [sortedTransformations, setSortedTransformations] = useState([]);
@@ -70,4 +70,3 @@ TransformationsList.propTypes = {
   transformations: PropTypes.arrayOf(PropTypes.object),
   allTransformations: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
-TransformationsList.defaultProps = { transformations: [] };


### PR DESCRIPTION
After this PR merged all default props will be replaced using default values syntax. More info https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis

Refs: [UIDEXP-376](https://folio-org.atlassian.net/browse/UIDEXP-376) 