### PR TITLE
UIDEXP-380: Rewrite tests which depends on stripes-data-transfer-comp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * React v19: refactor away from default props for functional components.фвв Refs UIDEXP-376.
 * Add info tip to field suppression. Refs UIDEXP-377
 * Update translation file with item's circulation notes. Refs UIDEXP-294.
+* Rewrite tests which depends on stripes-data-transfer-components.Refs UIDEXP-380.
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^10.4.7",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.1.10",
     "babel-jest": "^26.1.0",
     "chai": "^4.2.0",

--- a/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
+++ b/src/components/ErrorLogsView/utils/generateAffectedRecordInfo.test.js
@@ -1,11 +1,9 @@
-import { useIntl } from 'react-intl';
+import { IntlProvider, useIntl } from 'react-intl';
 
 import '../../../../test/jest/__mock__';
 
-import { getHookExecutionResult } from '@folio/stripes-data-transfer-components/jestUtils';
-
+import { renderHook } from '@testing-library/react-hooks';
 import { generateAffectedRecordInfo } from './generateAffectedRecordInfo';
-import { translationsProperties } from '../../../../test/helpers';
 import { errorLogs } from '../../../../test/bigtest/fixtures/errorLogs';
 
 const useGenerateAffectedRecordInfo = ({ logs }) => {
@@ -13,6 +11,22 @@ const useGenerateAffectedRecordInfo = ({ logs }) => {
 
   return { recordInfo: generateAffectedRecordInfo(logs, intl.formatMessage) };
 };
+
+const messages = {
+  'ui-data-export.errorLogs.record.Title': '"{recordType} Title": "{value}"',
+  'ui-data-export.errorLogs.record.UUID': '"{recordType} UUID": "{value}"',
+  'ui-data-export.errorLogs.record.HRID': '"{recordType} HRID": "{value}"',
+  'ui-data-export.errorLogs.recordAssociated.HRID': '"Associated {recordType} HRID": "{value}"',
+  'ui-data-export.errorLogs.recordAssociated.UUID': '"Associated {recordType} UUID": "{value}"',
+  'ui-data-export.errorLogs.inventoryRecordLink': '"Inventory record link": ',
+  'ui-data-export.errorLogs.recordAssociated.Title': '"Associated {recordType} Title": "{value}"',
+};
+
+const wrapper = ({ children }) => (
+  <IntlProvider locale="en" messages={messages}>
+    {children}
+  </IntlProvider>
+);
 
 describe('generateAffectedRecordInfo', () => {
   it('should return correct instance record info without affected records (affectedRecords field is provided but empty)', () => {
@@ -23,9 +37,9 @@ describe('generateAffectedRecordInfo', () => {
       recordType: 'INSTANCE',
       affectedRecords: [],
     };
-    const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs }], translationsProperties);
+    const { result } = renderHook(() => useGenerateAffectedRecordInfo({ logs }), { wrapper });
 
-    expect(recordInfo).toEqual([
+    expect(result.current.recordInfo).toEqual([
       '{',
       '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Instance HRID": "inst000000000022"',
@@ -41,9 +55,9 @@ describe('generateAffectedRecordInfo', () => {
       title: 'A semantic web primer',
       recordType: 'ITEM',
     };
-    const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs }], translationsProperties);
+    const { result } = renderHook(() => useGenerateAffectedRecordInfo({ logs }), { wrapper });
 
-    expect(recordInfo).toEqual([
+    expect(result.current.recordInfo).toEqual([
       '{',
       '"Item UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Item HRID": "inst000000000022"',
@@ -64,9 +78,9 @@ describe('generateAffectedRecordInfo', () => {
         affectedRecords: [],
       }],
     };
-    const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs }], translationsProperties);
+    const { result } = renderHook(() => useGenerateAffectedRecordInfo({ logs }), { wrapper });
 
-    expect(recordInfo).toEqual([
+    expect(result.current.recordInfo).toEqual([
       '{',
       '"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Instance HRID": "inst000000000022"',
@@ -78,25 +92,25 @@ describe('generateAffectedRecordInfo', () => {
   });
 
   it('should return correct record info with 2 level nesting', () => {
-    const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs: errorLogs[2].affectedRecord }], translationsProperties);
+    const { result } = renderHook(() => useGenerateAffectedRecordInfo({ logs: errorLogs[2].affectedRecord }), { wrapper });
 
-    expect(recordInfo[0]).toEqual('{');
-    expect(recordInfo[1]).toEqual('"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"');
-    expect(recordInfo[2]).toEqual('"Instance HRID": "inst000000000022"');
-    expect(recordInfo[3]).toEqual('"Instance Title": "A semantic web primer"');
-    expect(recordInfo[4].props.children[0]).toEqual('"Inventory record link": ');
-    expect(recordInfo[4].props.children[1].props).toEqual(expect.objectContaining({
+    expect(result.current.recordInfo[0]).toEqual('{');
+    expect(result.current.recordInfo[1]).toEqual('"Instance UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"');
+    expect(result.current.recordInfo[2]).toEqual('"Instance HRID": "inst000000000022"');
+    expect(result.current.recordInfo[3]).toEqual('"Instance Title": "A semantic web primer"');
+    expect(result.current.recordInfo[4].props.children[0]).toEqual('"Inventory record link": ');
+    expect(result.current.recordInfo[4].props.children[1].props).toEqual(expect.objectContaining({
       href: 'https://folio-snapshot-load.dev.folio.org/inventory/view/e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6',
       target: '_blank',
       children: 'https://folio-snapshot-load.dev.folio.org/inventory/view/e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6',
     }));
-    expect(recordInfo[5]).toEqual('"Associated Holdings UUID": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"');
-    expect(recordInfo[6]).toEqual('"Associated Holdings HRID": "hold000000000009"');
-    expect(recordInfo[7]).toEqual('"Associated Item UUID": "100d10bf-2f06-4aa0-be15-0b95b2d9f9e3"');
-    expect(recordInfo[8]).toEqual('"Associated Item HRID": "item000000000015"');
-    expect(recordInfo[9]).toEqual('"Associated Item UUID": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"');
-    expect(recordInfo[10]).toEqual('"Associated Item HRID": "item000000000014"');
-    expect(recordInfo[11]).toEqual('}');
+    expect(result.current.recordInfo[5]).toEqual('"Associated Holdings UUID": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"');
+    expect(result.current.recordInfo[6]).toEqual('"Associated Holdings HRID": "hold000000000009"');
+    expect(result.current.recordInfo[7]).toEqual('"Associated Item UUID": "100d10bf-2f06-4aa0-be15-0b95b2d9f9e3"');
+    expect(result.current.recordInfo[8]).toEqual('"Associated Item HRID": "item000000000015"');
+    expect(result.current.recordInfo[9]).toEqual('"Associated Item UUID": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"');
+    expect(result.current.recordInfo[10]).toEqual('"Associated Item HRID": "item000000000014"');
+    expect(result.current.recordInfo[11]).toEqual('}');
   });
 
   it('should provide title only for instance', () => {
@@ -112,9 +126,9 @@ describe('generateAffectedRecordInfo', () => {
         affectedRecords: [],
       }],
     };
-    const { recordInfo } = getHookExecutionResult(useGenerateAffectedRecordInfo, [{ logs }], translationsProperties);
+    const { result } = renderHook(() => useGenerateAffectedRecordInfo({ logs }), { wrapper });
 
-    expect(recordInfo).toEqual([
+    expect(result.current.recordInfo).toEqual([
       '{',
       '"Holdings UUID": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39"',
       '"Holdings HRID": "inst000000000022"',


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIDEXP-380
Here we refactored the test that was using `getHookExecutionResult` from `stripes-data-transfer-components` that will be removed in the scope of https://github.com/folio-org/stripes-data-transfer-components/pull/308.