### PR TITLE
UIDEXP-382 Add consistency to Add mapping profile form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Rewrite tests which depends on stripes-data-transfer-components.Refs UIDEXP-380.
 * Improve field suppression validation. Refs UIDEXP-378.
 * Error message  in error " Logs", if the user does not have the affiliation with the tenant. Refs UIDEXP-381.
-* Add consistency to Add mapping profile form. Refs UIDEXP-382.
+* Replace hover with click event for all Info icons on "Add mapping profile" form. Refs UIDEXP-382.
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Rewrite tests which depends on stripes-data-transfer-components.Refs UIDEXP-380.
 * Improve field suppression validation. Refs UIDEXP-378.
 * Error message  in error " Logs", if the user does not have the affiliation with the tenant. Refs UIDEXP-381.
+* Add consistency to Add mapping profile form. Refs UIDEXP-382.
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
+++ b/src/settings/MappingProfiles/MappingProfilesForm/MappingProfilesForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   FormattedMessage,
@@ -62,7 +62,6 @@ const MappingProfilesFormComponent = props => {
     onTypeDisable,
   } = props;
   const intl = useIntl();
-  const [open, setOpen] = useState(false);
 
   const openTransformationModalButtonId = isEditMode ? 'editTransformations' : 'addTransformations';
   const isSubmitButtonDisabled = isFormDirty ? !isFormDirty : pristine || submitting;
@@ -71,13 +70,10 @@ const MappingProfilesFormComponent = props => {
   const fieldSuppressionFieldLabel = (
     <>
       <FormattedMessage id="ui-data-export.fieldsSuppression" />
-      <span onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
-        <InfoPopover
-          allowAnchorClick
-          open={open}
-          content={<FormattedMessage id="ui-data-export.suppressInfo" />}
-        />
-      </span>
+      <InfoPopover
+        iconSize="medium"
+        content={<FormattedMessage id="ui-data-export.suppressInfo" />}
+      />
     </>
   );
 


### PR DESCRIPTION
After this PR merged, -  info icon for Fields suppression field will be consistent with another info icons on this form (show on click instead of hover + size change).

![UIDEXP-382](https://github.com/folio-org/ui-data-export/assets/86330150/d3430007-59fd-41b9-8cd5-deb445327ab8)
