### PR TITLE
UIDEXP-396: “Something went wrong“ page with error appears when save transformation form with empty row of “Instance” record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 * Transformation form: empty indicators and subfields display. Refs UIDEXP-385.
 * Mapping profile - modify validation of transformation elements. Refs UIDEXP-384.
 * Sort logs by file name. Refs UIDEXP-317.
+* “Something went wrong“ page with error appears when save transformation form with empty row of “Instance” record type.
+  Refs UIDEXP-396.
 
 ## [6.1.0](https://github.com/folio-org/ui-data-export/tree/v6.1.0) (2024-03-19)
 

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.js
@@ -47,10 +47,6 @@ export const isInstanceTransformationEmpty = transformation => {
 };
 
 export const validateRawTransformation = transformation => {
-  if (isInstanceTransformationEmpty(transformation)) {
-    return { isTransformationValid: true };
-  }
-
   const { rawTransformation = {} } = transformation;
   const {
     marcField = '',

--- a/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
+++ b/src/settings/MappingProfiles/MappingProfilesTransformationsModal/validateTransformations.test.js
@@ -244,13 +244,19 @@ describe('validateRawTransformation', () => {
     });
   });
 
-  it('should validate raw transformation as valid when all fields are absent and record has an instance type', () => {
+  it('should validate raw transformation as invalid when all fields are absent and record has an instance type', () => {
     const transformation = { recordType: 'INSTANCE' };
 
-    expect(validateRawTransformation(transformation)).toEqual({ isTransformationValid: true });
+    expect(validateRawTransformation(transformation)).toEqual({
+      isTransformationValid: false,
+      indicator1: true,
+      indicator2: true,
+      marcField: false,
+      subfield: false,
+    });
   });
 
-  it('should validate raw transformation as valid when all fields are present but empty and record has an instance type', () => {
+  it('should validate raw transformation as invalid when all fields are present but empty and record has an instance type', () => {
     const transformation = {
       recordType: 'INSTANCE',
       rawTransformation: {
@@ -261,7 +267,13 @@ describe('validateRawTransformation', () => {
       },
     };
 
-    expect(validateRawTransformation(transformation)).toEqual({ isTransformationValid: true });
+    expect(validateRawTransformation(transformation)).toEqual({
+      indicator1: true,
+      indicator2: true,
+      marcField: false,
+      subfield: false,
+      isTransformationValid: false,
+    });
   });
 });
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIDEXP-396

Here we removed old validation case for `instances`. So now we can't save empty `transformation` for all types of records.