### PR TITLE
UIDEXP-399: Add translation to “error.instance.noPermission” error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* Add translation to “error.instance.noPermission” error. Refs UIDEXP-399.
+
 ## [6.2.0](https://github.com/folio-org/ui-data-export/tree/v6.2.0) (2024-10-30)
 [Full Changelog](https://github.com/folio-org/ui-data-export/compare/v6.1.4...v6.2.0)
 

--- a/src/components/ErrorLogsView/ErrorLogsView.js
+++ b/src/components/ErrorLogsView/ErrorLogsView.js
@@ -12,8 +12,7 @@ import css from './ErrorLogsView.css';
 
 const formatErrorReasonMessageValues = (errorMessageValues = []) => {
   return errorMessageValues.reduce((formattedValues, value, index) => {
-    formattedValues[`value${index + 1}`] = value;
-
+    formattedValues[`value${index + 1}`] = Array.isArray(value) ? value.join(', ') : value;
     return formattedValues;
   }, {});
 };

--- a/translations/ui-data-export/en.json
+++ b/translations/ui-data-export/en.json
@@ -330,6 +330,7 @@
   "error.noAffiliation": "{value1} - the user {value2} does not have permissions to access the holdings record in {value3} data tenant.",
   "error.userNotHaveAccessForHoldingsTenantData": "{value1} - the user {value2} does not have permissions to access the holdings record in {value3} data tenant.",
   "error.tenantNotFoundForHolding": "No tenant can be found for holdings record {value1}.",
+  "error.instance.noPermission": "{value1} the user {value2} does not have permissions to view holdings or items in {value3} data tenant(s). Holdings and item records from this tenant were omitted during export.",
 
   "column.errors.duplicatesWithOthers": "{failedOther}, {failedSrs} duplicate(s)",
   "column.errors.duplicates": "{failedSrs} duplicate(s)"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIDEXP-399

Here we added error handling for `error.instance.noPermission`. For now, we receive as `value 3` string, but after https://folio-org.atlassian.net/browse/MDEXP-805 it will be an array, we added `Array.isArray(value) ? value.join(', ') : value;`

The current flow looks like this 

https://github.com/user-attachments/assets/70bd76ef-2c98-4e31-915a-bd167e87b3bc

<img width="1476" alt="Screenshot 2024-11-01 at 11 42 33" src="https://github.com/user-attachments/assets/11645c74-8b56-4c77-bacc-5fe4777753aa">
